### PR TITLE
♻️ Add latestRulesQuery to fetch rules data

### DIFF
--- a/app/rules/latest-rules/client-page.tsx
+++ b/app/rules/latest-rules/client-page.tsx
@@ -7,8 +7,8 @@ import Link from 'next/link';
 import SortDropdown from '@/components/SortDropdown';
 
 const sortOptions = [
-  { value: 'Updated', label: 'Recently Updated', field: 'lastUpdated' },
-  { value: 'Created', label: 'Recently Added', field: 'created' },
+  { value: 'lastUpdated', label: 'Recently Updated'},
+  { value: 'created', label: 'Recently Added'},
 ];
 
 export default function ClientLatestRulesPage({ size }: { size: number }) {
@@ -17,23 +17,14 @@ export default function ClientLatestRulesPage({ size }: { size: number }) {
 
   const getLatestRules = async () => {
     try {
-      const { data } = await client.queries.ruleConnection({});
-      
+      const { data } = await client.queries.latestRulesQuery({
+        size: Number(size),
+        sortOption,
+      });
+
       if (data?.ruleConnection?.edges) {
-        const sortedRules = data.ruleConnection.edges
-          .map((edge: any) => edge.node)
-          .sort((a: any, b: any) => {
-            const sortField = sortOptions.find(option => option.value === sortOption)?.field;
-
-            if (!sortField) {
-              return 0;
-            }
-
-            const aDate = new Date(a[sortField]).getTime();
-            const bDate = new Date(b[sortField]).getTime();
-            return bDate - aDate;
-          });
-
+        const sortedRules = data.ruleConnection.edges.map((edge: any) => edge.node);
+  
         setRules(sortedRules);
       } else {
         console.error('No rules found');

--- a/tina/queries/queries.gql
+++ b/tina/queries/queries.gql
@@ -1,0 +1,15 @@
+query latestRulesQuery($size: Float, $sortOption: String) {
+  ruleConnection(last: $size, sort: $sortOption) {
+    edges {
+      node {
+        id
+        title
+        lastUpdated
+        created
+       _sys {
+          filename
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description
✏️ 
Relates to https://github.com/SSWConsulting/SSW.Rules/issues/1722
Use a better way to retrieve rules for the "latest rules" page

## Screenshot (optional)
✏️ 

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->