### PR TITLE
Add Related Categories Section to Rule Page

### DIFF
--- a/app/[filename]/client-rule-page.tsx
+++ b/app/[filename]/client-rule-page.tsx
@@ -1,15 +1,17 @@
 "use client";
 
 import { embedComponents } from "@/components/embeds";
+import Link from "next/link";
 import { tinaField, useTina } from "tinacms/dist/react";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
 
 export interface ClientRulePageProps {
-  ruleQueryProps;
+  ruleQueryProps,
+  relatedCategories
 }
 
 export default function ClientRulePage(props: ClientRulePageProps) {
-  const { ruleQueryProps } = props;
+  const { ruleQueryProps, relatedCategories } = props;
 
   const ruleData = useTina({
     query: ruleQueryProps?.query,
@@ -27,6 +29,24 @@ export default function ClientRulePage(props: ClientRulePageProps) {
       <div data-tina-field={tinaField(rule, "body")}>
         <TinaMarkdown content={rule.body} components={embedComponents} />
       </div>
+
+      {relatedCategories && (
+        <div className="mt-8 mb-4">
+          <h2 className="font-semibold">Categories:</h2>
+          <ul className="list-disc ml-6">
+            {relatedCategories.map((cat) => (
+              <li key={cat.categoryUri}>
+                <Link
+                  href={`/${cat.categoryUri}`}
+                  className="text-blue-600 underline"
+                >
+                  {cat.categoryTitle}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </>
   );
 }

--- a/app/[filename]/page.tsx
+++ b/app/[filename]/page.tsx
@@ -35,10 +35,18 @@ const getRuleData = async (filename: string) => {
       relativePath: filename + "/rule.md",
     });
 
+    //TODO: This is hard coded for PoC, will definitely be moved to a config file
+    const mappingRes = await fetch(
+      "https://raw.githubusercontent.com/SSWConsulting/SSW.Rules.Content/tina/main/scripts/tina-migration/rule-category-mapping.json"
+    );
+    const mappingJson = await mappingRes.json();
+    const relatedCategories = mappingJson[tinaProps.data.rule.uri] || [];
+
     return {
       data: tinaProps.data,
       query: tinaProps.query,
       variables: tinaProps.variables,
+      relatedCategories,
     };
   } catch (error) {
     console.error("Error fetching rule data:", error);
@@ -92,7 +100,7 @@ export default async function Page({
     return (
       <Layout>
         <Section>
-          <ClientRulePage ruleQueryProps={rule} />
+          <ClientRulePage ruleQueryProps={rule} relatedCategories={rule.relatedCategories} />
         </Section>
       </Layout>
     );


### PR DESCRIPTION
## Description
✏️ 
Relates to https://github.com/SSWConsulting/SSW.Rules/issues/1719

Added related categories for each rule's page

## Screenshot (optional)
✏️ 
![image](https://github.com/user-attachments/assets/1c9bc65c-c89c-46c1-98bd-ee0a20d4d715)


<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->