### PR TITLE
♻️ Add archived boolean field to rules with validation for archivedReason

### DIFF
--- a/tina/collection/rule.tsx
+++ b/tina/collection/rule.tsx
@@ -39,7 +39,7 @@ const Rule: Collection = {
         ...values,
         lastUpdated: new Date().toISOString(),
       }
-    }
+    },
   },
   fields: [
     {
@@ -126,12 +126,6 @@ const Rule: Collection = {
     },
     {
       type: "string",
-      name: "archivedreason",
-      label: "Archived Reason",
-      description: "If this rule has been archived, summarise why here.",
-    },
-    {
-      type: "string",
       name: "guid",
       label: "Guid",
       description:
@@ -153,6 +147,29 @@ const Rule: Collection = {
       label: "Body",
       isBody: true,
       templates: embedTemplates,
+    },
+    {
+      type: "boolean",
+      name: "archived",
+      label: "Archived",
+      description: "Mark this rule as archived.",
+    },
+    {
+      type: "string",
+      name: "archivedreason",
+      label: "Archived Reason",
+      description: "If this rule has been archived, summarise why here. Only required if 'Archived' is checked.",
+      ui: {
+        validate: (value, allValue) => {
+          if (!allValue.archived && value?.length) {
+            return "You cannot provide an archived reason if the rule is not archived.";
+          }
+
+          if (allValue.archived && !value?.length) {
+            return "Please provide a reason when archiving this rule.";
+          }
+        },
+      },
     },
   ],
 };


### PR DESCRIPTION
## Description
✏️ 
Relates to https://github.com/SSWConsulting/SSW.Rules/issues/1806

Introduces a boolean field to mark rules as archived. Adds validation logic to ensure the archived reason is only provided when the rule is marked as archived

## Screenshot (optional)
✏️ 

https://github.com/user-attachments/assets/6164870e-4da7-4e70-b5fe-d1eed0d5fbdc



<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->