### PR TITLE
♻️ Adds pagination support for top category query

### DIFF
--- a/app/[filename]/page.tsx
+++ b/app/[filename]/page.tsx
@@ -11,23 +11,35 @@ import categoryTitleIndex from '@/category-uri-title-map.json';
 export const revalidate = 300;
 
 const getFullRelativePathFromFilename = async (filename: string): Promise<string | null> => {
-  const res = await client.queries.topCategoryWithIndexQuery();
-  const topCategories = res?.data.categoryConnection?.edges || [];
+  let hasNextPage = true;
+  let after: string | null = null;
 
-  for (const edge of topCategories) {
-    const node = edge?.node;
-    if (node?.__typename === "CategoryTop_category") {
-      const topRelativePath = node._sys.relativePath;
-      const topDir = topRelativePath.replace("/index.mdx", "");
+  while (hasNextPage) {
+    const res = await client.queries.topCategoryWithIndexQuery({
+      first: 50,
+      after,
+    });
 
-      const children = node.index || [];
-      for (const child of children) {
-        // @ts-ignore
-        if (child?.category?._sys.filename === filename) {
-          return `${topDir}/${filename}.mdx`;
+    const topCategories = res?.data.categoryConnection?.edges || [];
+
+    for (const edge of topCategories) {
+      const node = edge?.node;
+      if (node?.__typename === "CategoryTop_category") {
+        const topRelativePath = node._sys.relativePath;
+        const topDir = topRelativePath.replace("/index.mdx", "");
+
+        const children = node.index || [];
+        for (const child of children) {
+          // @ts-ignore
+          if (child?.category?._sys?.filename === filename) {
+            return `${topDir}/${filename}.mdx`;
+          }
         }
       }
     }
+
+    hasNextPage = res?.data?.categoryConnection?.pageInfo?.hasNextPage;
+    after = res?.data?.categoryConnection?.pageInfo?.endCursor;
   }
 
   return null;

--- a/tina/queries/queries.gql
+++ b/tina/queries/queries.gql
@@ -46,8 +46,8 @@ query homepageCategoriesQuery($first: Float, $after: String) {
   }
 }
 
-query topCategoryWithIndexQuery {
-  categoryConnection {
+query topCategoryWithIndexQuery($first: Float, $after: String) {
+  categoryConnection(first: $first, after: $after) {
     edges {
       node {
         __typename
@@ -69,8 +69,13 @@ query topCategoryWithIndexQuery {
         }
       }
     }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
   }
 }
+
 
 query categoryWithRulesQuery($relativePath: String!) {
   category(relativePath: $relativePath) {


### PR DESCRIPTION
## Description
✏️ 
Relates to https://github.com/SSWConsulting/SSW.Rules/issues/1833

Fixed the issue where some categories were missing due to the default page limit in each query.

## Screenshot (optional)
✏️ 

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->