### PR TITLE
✨Adds support for custom text highlighting in Markdown

### DIFF
--- a/app/[filename]/client-rule-page.tsx
+++ b/app/[filename]/client-rule-page.tsx
@@ -17,6 +17,7 @@ import {
 import Link from "next/link";
 import { useMemo } from "react";
 import { formatDateLong, timeAgo } from "@/lib/dateUtils";
+import MarkdownComponentMapping from "@/components/tina-markdown/markdown-component-mapping";
 
 export interface ClientRulePageProps {
   ruleQueryProps;
@@ -113,10 +114,7 @@ export default function ClientRulePage(props: ClientRulePageProps) {
           <div data-tina-field={tinaField(rule, "body")} className="mt-8">
             <TinaMarkdown
               content={rule?.body}
-              components={{
-                ...embedComponents,
-                ...typographyComponents,
-              }}
+              components={MarkdownComponentMapping}
             />
           </div>
         </Card>

--- a/components/tina-markdown/markdown-component-mapping.tsx
+++ b/components/tina-markdown/markdown-component-mapping.tsx
@@ -1,0 +1,47 @@
+import { Components } from "tinacms/dist/rich-text";
+import React from "react";
+
+import { embedComponents } from "@/components/embeds";
+import { typographyComponents } from "@/components/typography-components";
+
+export function renderTextWithHighlight(content): React.ReactNode {
+    if (typeof content !== "string") return content;
+  
+    const parts = content.split(/(==[^=]+==|<mark>.*?<\/mark>)/g);
+  
+    return parts.map((part, index) => {
+      if (/^==[^=]+==$/.test(part)) {
+        return <mark key={index} className="bg-yellow-200 px-1 py-0.5 rounded-sm">{part.slice(2, -2)}</mark>
+      }
+  
+      if (/^<mark>.*<\/mark>$/.test(part)) {
+        const inner = part.replace(/^<mark>(.*?)<\/mark>$/, "$1");
+        return <mark key={index} className="bg-yellow-200 px-1 py-0.5 rounded-sm">{inner}</mark>
+      }
+  
+      return <span key={index}>{part}</span>;
+    });
+}
+
+
+export const MarkdownComponentMapping: Components<any> = {
+  ...embedComponents,
+  ...typographyComponents,
+  p: (props) => {
+    const content = props?.children?.props?.content;
+
+    if (Array.isArray(content)) {
+      const fullText = content
+        .map((node) => (typeof node.text === "string" ? node.text : ""))
+        .join("");
+
+      if (fullText.includes("==") || fullText.includes("<mark>")) {
+        return <p>{renderTextWithHighlight(fullText)}</p>;
+      }
+    }
+
+    return <p {...props} />;
+  }
+};
+
+export default MarkdownComponentMapping;


### PR DESCRIPTION
## Description
✏️ 
Relates to https://github.com/SSWConsulting/SSW.Rules/issues/1822

Based on https://github.com/tinacms/tinacms/issues/5890#issuecomment-3112353087, added support of highlight text for our PoC project

## Screenshot (optional)
✏️ 
<img width="1810" height="1318" alt="image" src="https://github.com/user-attachments/assets/5265269a-bbea-48a6-8eac-4cfcfb38a7f5" />

<img width="1210" height="1006" alt="image" src="https://github.com/user-attachments/assets/f2c33dd5-9f8d-497a-a20c-8b5ae85ecb81" />


<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->