### PR TITLE
♻️ Replace default Algolia SearchBox with custom search component

### DIFF
--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -1,18 +1,58 @@
 'use client';
 
-import { Hits, InstantSearch, SearchBox } from 'react-instantsearch-hooks-web';
-import { useState } from 'react';
+import { useSearchBox, Hits, InstantSearch } from 'react-instantsearch-hooks-web';
+import { useState, FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
 import { searchClient } from '@/lib/algoliaClient';
-import SearchNavigator from './SearchNavigator';
 import SortDropdown from './SortDropdown';
+import SearchNavigator from './SearchNavigator';
 import { sortItems } from '@/utils/sortUtils';
 import Link from 'next/link';
+import { Search } from 'lucide-react';
 
 const sortOptions = [
     { value: 'Updated', label: 'Recently Updated', field: 'lastUpdated' },
     { value: 'Created', label: 'Recently Added', field: 'created' },
 ];
+
 const Hit = ({ hit }: { hit: any }) => <Link href={`/${hit.slug}`}>{hit.title}</Link>;
+
+function CustomSearchBox({ onSubmit }: { onSubmit: (query: string) => void }) {
+    const { query, refine } = useSearchBox();
+    const [inputValue, setInputValue] = useState(query || '');
+    const router = useRouter();
+
+    const handleSubmit = (e: FormEvent) => {
+        e.preventDefault();
+        const trimmed = inputValue.trim();
+        if (!trimmed) {
+            router.push('/');
+        } else {
+            refine(trimmed);
+            onSubmit(trimmed);
+        }
+    };
+
+    return (
+        <form onSubmit={handleSubmit} className="p-3">
+            <div className="relative">
+                <input
+                    type="text"
+                    className="block w-full h-10 pl-3 pr-10 py-2 bg-white border placeholder-slate-400 focus:ring-gray-400 rounded-md"
+                    placeholder="Search..."
+                    value={inputValue}
+                    onChange={(e) => setInputValue(e.target.value)}
+                />
+                <span
+                    className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-slate-400"
+                    aria-hidden="true"
+                >
+                    <Search className="w-5 h-5" />
+                </span>
+            </div>
+        </form>
+    );
+}
 
 export default function SearchBar({ keyword = '' }: { keyword?: string }) {
     const [submitted, setSubmitted] = useState(false);
@@ -22,22 +62,25 @@ export default function SearchBar({ keyword = '' }: { keyword?: string }) {
         <InstantSearch
             searchClient={searchClient}
             indexName={process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME!}
-            initialUiState={{ [process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME!]: { query: keyword } }}
+            initialUiState={{
+                [process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME!]: {
+                    query: keyword,
+                },
+            }}
         >
-            <SearchBox
-                classNames={{
-                    root: 'p-3',
-                    form: 'relative',
-                    input: 'block w-full h-10 pl-9 pr-3 py-2 bg-white border border-slate-300 placeholder-slate-400 focus:outline-none focus:border-sky-500 focus:ring-sky-500 rounded-md focus:ring-1',
-                    submitIcon: 'absolute top-3 left-3 bottom-0 w-4 h-4',
-                    resetIcon: 'hidden',
-                }}
-                searchAsYouType={false}
-                onSubmit={() => setSubmitted(true)}
+            <CustomSearchBox onSubmit={() => setSubmitted(true)} />
+            <SortDropdown
+                options={sortOptions}
+                selectedValue={sortOption}
+                onChange={setSortOption}
             />
-            <SortDropdown options={sortOptions} selectedValue={sortOption} onChange={setSortOption} />
             <SearchNavigator submitted={submitted} reset={() => setSubmitted(false)} />
-            <Hits hitComponent={Hit} transformItems={(items) => sortItems(items, sortOption, sortOptions)} />
+            <Hits
+                hitComponent={Hit}
+                transformItems={(items) =>
+                    sortItems(items, sortOption, sortOptions)
+                }
+            />
         </InstantSearch>
     );
 }


### PR DESCRIPTION
## Description
✏️ 
Relates to https://github.com/SSWConsulting/SSW.Rules/issues/1843

Replaced the default <SearchBox> with a custom component (using useSearchBox hook). In this way we can have a full control over search behavior.
## Screenshot (optional)
✏️ 
<img width="2813" height="1440" alt="image" src="https://github.com/user-attachments/assets/6436d1e7-2faf-4d6c-abff-6884cd227065" />


<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->