### PR TITLE
🐛 Profile - Prevent auto logout due to Next prefetch

### DIFF
--- a/components/auth/UserDropdown.tsx
+++ b/components/auth/UserDropdown.tsx
@@ -62,27 +62,32 @@ export default function UserDropdown() {
           <div className="border-t border-gray-200 dark:border-gray-700" />
 
           <nav className="p-1">
-            <MenuItem href={`https://www.github.com/${u.nickname}`}><FaGithub size="18" /> GitHub Profile</MenuItem>
-            <MenuItem href="/rules/profile"><FaUser size="18" /> SSW.Rules Profile</MenuItem>
-            <MenuItem as="a" href="/auth/logout">
-              <FaSignOutAlt size="18" />
-              Sign Out
-            </MenuItem>
+            <a
+              href={`https://www.github.com/${u.nickname}`}
+              target="_blank"
+              rel="noreferrer"
+              className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-sm hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50 dark:hover:bg-gray-800"
+            >
+              <FaGithub size="18" /> GitHub Profile
+            </a>
+
+            <Link
+              href="/rules/profile"
+              prefetch={false}
+              className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-sm hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50 dark:hover:bg-gray-800"
+            >
+              <FaUser size="18" /> SSW.Rules Profile
+            </Link>
+
+            <a
+              href="/auth/logout"
+              className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-sm hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50 dark:hover:bg-gray-800"
+            >
+              <FaSignOutAlt size="18" /> Sign Out
+            </a>
           </nav>
         </div>
       )}
     </div>
-  );
-}
-
-function MenuItem(props) {
-  const { as, className = '', children, ...rest } = props;
-  const base =
-    'flex w-full items-center gap-2 rounded-xl px-3 py-2 text-sm hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50 dark:hover:bg-gray-800';
-
-  return (
-    <Link className={`${base} ${className}`} {...(rest)}>
-      {children}
-    </Link>
   );
 }


### PR DESCRIPTION

## Description
✏️ 
Relates to https://github.com/SSWConsulting/SSW.Rules/issues/1874

Next.js Link prefetch was hitting /api/auth/logout in production, which cleared the session and logged users out when opening the profile dropdown.

Changes:
- Replaced logout Link with a plain <a> to avoid prefetch.

## Screenshot (optional)
✏️ 

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->