### PR TITLE
Adding the missing 3rd button "Show only titles", and adjust the number of categories with title.

### DIFF
--- a/app/[filename]/client-category-page.tsx
+++ b/app/[filename]/client-category-page.tsx
@@ -1,14 +1,14 @@
-"use client";
+'use client';
 
-import React, { useEffect, useMemo, useState } from "react";
-import { tinaField, useTina } from "tinacms/dist/react";
-import Link from "next/link";
-import { TinaMarkdown } from "tinacms/dist/rich-text";
-import MarkdownComponentMapping from "@/components/tina-markdown/markdown-component-mapping";
-import RuleList from "@/components/rule-list";
-import { useUser, getAccessToken } from "@auth0/nextjs-auth0";
-import { BookmarkService } from "@/lib/bookmarkService";
-import Breadcrumbs from "@/components/Breadcrumbs";
+import React, { useEffect, useMemo, useState } from 'react';
+import { tinaField, useTina } from 'tinacms/dist/react';
+import Link from 'next/link';
+import { TinaMarkdown } from 'tinacms/dist/rich-text';
+import MarkdownComponentMapping from '@/components/tina-markdown/markdown-component-mapping';
+import RuleList from '@/components/rule-list';
+import { useUser, getAccessToken } from '@auth0/nextjs-auth0';
+import { BookmarkService } from '@/lib/bookmarkService';
+import Breadcrumbs from '@/components/Breadcrumbs';
 
 export interface ClientCategoryPageProps {
   categoryQueryProps: {
@@ -30,7 +30,7 @@ export default function ClientCategoryPage(props: ClientCategoryPageProps) {
   const { user, isLoading: authLoading } = useUser();
   const category = data?.category;
   const baseRules = useMemo(() => {
-    return category?.index.flatMap(i => i.rule) || [];
+    return category?.index.flatMap((i) => i.rule) || [];
   }, [category]);
   const [annotatedRules, setAnnotatedRules] = useState<any[]>(baseRules);
   const [bookmarkedGuids, setBookmarkedGuids] = useState<string[]>([]);
@@ -52,16 +52,16 @@ export default function ClientCategoryPage(props: ClientCategoryPageProps) {
           return;
         }
         const bookmarkResult: any = await BookmarkService.getUserBookmarks(user.sub, accessToken);
-        const guids: string[] = (bookmarkResult?.bookmarkedRules || [])
-          .map((b: any) => b?.ruleGuid)
-          .filter((g: any): g is string => Boolean(g));
+        const guids: string[] = (bookmarkResult?.bookmarkedRules || []).map((b: any) => b?.ruleGuid).filter((g: any): g is string => Boolean(g));
         if (!cancelled) setBookmarkedGuids(guids);
       } catch {
         if (!cancelled) setBookmarkedGuids([]);
       }
     }
     fetchBookmarks();
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [authLoading, user?.sub]);
 
   // Derive annotated rules when baseRules or bookmarks change
@@ -81,26 +81,19 @@ export default function ClientCategoryPage(props: ClientCategoryPageProps) {
   return (
     <div>
       <Breadcrumbs isCategory breadcrumbText={category?.title} />
-      <div className="flex">
-        <div className="w-full lg:w-2/3 bg-white pt-4 p-6 rounded shadow">
-          <h1 className="m-0 mb-2 text-ssw-red font-bold">{category?.title}</h1>
-          <div data-tina-field={tinaField(category, "body")}
-            className="text-md">
-            <TinaMarkdown
-              content={category?.body}
-              components={MarkdownComponentMapping}
-            />
+      <div className='flex'>
+        <div className='w-full lg:w-2/3 bg-white pt-4 p-6 rounded shadow'>
+          <h1 className='m-0 mb-2 text-ssw-red font-bold'>{category?.title}</h1>
+          <div data-tina-field={tinaField(category, 'body')} className='text-md'>
+            <TinaMarkdown content={category?.body} components={MarkdownComponentMapping} />
           </div>
-          <RuleList
-            rules={annotatedRules}
-            categoryUri={path}
-            type="category" />
+          <RuleList rules={annotatedRules} categoryUri={path} type='category' />
         </div>
-        <div className="hidden lg:w-1/3 lg:block md:hidden p-6 pr-0">
-          <ol className="border-l-3 border-gray-300 pl-6">
+        <div className='hidden lg:w-1/3 lg:block md:hidden p-6 pr-0'>
+          <ol className='border-l-3 border-gray-300 pl-6'>
             {annotatedRules.map((rule) => (
-              <li key={`${rule.guid}-${rule.uri}`} className="py-1 ml-4">
-                <Link href={rule.uri} className="text-gray-700 hover:text-ssw-red">
+              <li key={`${rule.guid}-${rule.uri}`} className='py-1 ml-4'>
+                <Link href={rule.uri} className='text-gray-700 hover:text-ssw-red'>
                   {rule.title}
                 </Link>
               </li>

--- a/app/[filename]/client-category-page.tsx
+++ b/app/[filename]/client-category-page.tsx
@@ -81,19 +81,19 @@ export default function ClientCategoryPage(props: ClientCategoryPageProps) {
   return (
     <div>
       <Breadcrumbs isCategory breadcrumbText={category?.title} />
-      <div className='flex'>
-        <div className='w-full lg:w-2/3 bg-white pt-4 p-6 rounded shadow'>
-          <h1 className='m-0 mb-2 text-ssw-red font-bold'>{category?.title}</h1>
-          <div data-tina-field={tinaField(category, 'body')} className='text-md'>
+      <div className="flex">
+        <div className="w-full lg:w-2/3 bg-white pt-4 p-6 rounded shadow">
+          <h1 className="m-0 mb-2 text-ssw-red font-bold">{category?.title}</h1>
+          <div data-tina-field={tinaField(category, 'body')} className="text-md">
             <TinaMarkdown content={category?.body} components={MarkdownComponentMapping} />
           </div>
-          <RuleList rules={annotatedRules} categoryUri={path} type='category' />
+          <RuleList rules={annotatedRules} categoryUri={path} type="category" />
         </div>
-        <div className='hidden lg:w-1/3 lg:block md:hidden p-6 pr-0'>
-          <ol className='border-l-3 border-gray-300 pl-6'>
+        <div className="hidden lg:w-1/3 lg:block md:hidden p-6 pr-0">
+          <ol className="border-l-3 border-gray-300 pl-6">
             {annotatedRules.map((rule) => (
-              <li key={`${rule.guid}-${rule.uri}`} className='py-1 ml-4'>
-                <Link href={rule.uri} className='text-gray-700 hover:text-ssw-red'>
+              <li key={`${rule.guid}-${rule.uri}`} className="py-1 ml-4">
+                <Link href={rule.uri} className="text-gray-700 hover:text-ssw-red">
                   {rule.title}
                 </Link>
               </li>

--- a/app/[filename]/client-category-page.tsx
+++ b/app/[filename]/client-category-page.tsx
@@ -1,14 +1,14 @@
 'use client';
 
-import React, { useEffect, useMemo, useState } from 'react';
-import { tinaField, useTina } from 'tinacms/dist/react';
-import Link from 'next/link';
-import { TinaMarkdown } from 'tinacms/dist/rich-text';
-import MarkdownComponentMapping from '@/components/tina-markdown/markdown-component-mapping';
-import RuleList from '@/components/rule-list';
-import { useUser, getAccessToken } from '@auth0/nextjs-auth0';
-import { BookmarkService } from '@/lib/bookmarkService';
-import Breadcrumbs from '@/components/Breadcrumbs';
+import React, { useEffect, useMemo, useState } from "react";
+import { tinaField, useTina } from "tinacms/dist/react";
+import Link from "next/link";
+import { TinaMarkdown } from "tinacms/dist/rich-text";
+import MarkdownComponentMapping from "@/components/tina-markdown/markdown-component-mapping";
+import RuleList from "@/components/rule-list";
+import { useUser, getAccessToken } from "@auth0/nextjs-auth0";
+import { BookmarkService } from "@/lib/bookmarkService";
+import Breadcrumbs from "@/components/Breadcrumbs";
 
 export interface ClientCategoryPageProps {
   categoryQueryProps: {

--- a/components/radio-button/radio-button.tsx
+++ b/components/radio-button/radio-button.tsx
@@ -10,39 +10,33 @@ interface RadioButtonProps {
   labelText: string;
 }
 
-const RadioButton: React.FC<RadioButtonProps> = ({
-  id,
-  value,
-  selectedOption,
-  handleOptionChange,
-  labelText
-}) => {
+const RadioButton: React.FC<RadioButtonProps> = ({ id, value, selectedOption, handleOptionChange, labelText }) => {
   const isSelected = selectedOption === value;
-  
+
   const handleButtonClick = () => {
     // Create a synthetic change event to match the expected interface
     const syntheticEvent = {
       target: {
         value: value,
         type: 'radio',
-        checked: true
-      }
+        checked: true,
+      },
     } as React.ChangeEvent<HTMLInputElement>;
-    
+
     handleOptionChange(syntheticEvent);
   };
-  
+
   return (
-    <button type="button" id={id}
+    <button
+      type="button"
+      id={id}
       className={`group px-4 py-1 text-sm border rounded cursor-pointer hover:text-white transition-colors ${
         isSelected ? 'bg-ssw-red' : 'bg-white hover:bg-ssw-red'
       }`}
       onClick={handleButtonClick}
       aria-pressed={isSelected}
     >
-      <span className={`transition-colors ${isSelected ? 'text-white' : 'text-gray-700 group-hover:text-white'}`}>
-        {labelText}
-      </span>
+      <span className={`transition-colors ${isSelected ? 'text-white' : 'text-gray-700 group-hover:text-white'}`}>{labelText}</span>
     </button>
   );
 };

--- a/components/radio-button/radio-button.tsx
+++ b/components/radio-button/radio-button.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 
 interface RadioButtonProps {
   id: string;
-  name: string;
   value: string;
   selectedOption: string;
   handleOptionChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -13,7 +12,6 @@ interface RadioButtonProps {
 
 const RadioButton: React.FC<RadioButtonProps> = ({
   id,
-  name,
   value,
   selectedOption,
   handleOptionChange,
@@ -26,7 +24,6 @@ const RadioButton: React.FC<RadioButtonProps> = ({
     const syntheticEvent = {
       target: {
         value: value,
-        name: name,
         type: 'radio',
         checked: true
       }

--- a/components/rule-list/rule-list-item-header.tsx
+++ b/components/rule-list/rule-list-item-header.tsx
@@ -51,24 +51,24 @@ const RuleListItemHeader: React.FC<RuleListItemHeaderProps> = ({ rule, showBookm
 
   return (
     <section>
-      <div className='mt-2 flex items-center flex-col justify-between sm:flex-row'>
-        <div className='flex gap-4 md:gap-2 md:mr-2'>
-          <span className='text-sm text-gray-500'>#{index + 1}</span>
-          <h2 className='m-0 text-2xl'>
-            <Link href={`../${rule.uri}`} ref={linkRef} className='no-underline'>
+      <div className="mt-2 flex items-center flex-col justify-between sm:flex-row">
+        <div className="flex gap-4 md:gap-2 md:mr-2">
+          <span className="text-sm text-gray-500">#{index + 1}</span>
+          <h2 className="m-0 text-2xl">
+            <Link href={`../${rule.uri}`} ref={linkRef} className="no-underline">
               {rule.title}
             </Link>
           </h2>
         </div>
 
         {showBookmark && (
-          <div className='profile-rule-buttons flex gap-3 justify-center mt-4 md:mt-0'>
+          <div className="profile-rule-buttons flex gap-3 justify-center mt-4 md:mt-0">
             <Bookmark ruleGuid={rule.guid} isBookmarked={isBookmarked} onBookmarkToggle={handleBookmarkToggle} />
             <IconLink href={`./admin#/~/${rule?.uri}`} children={<RiPencilLine size={ICON_SIZE} />} />
             <IconLink
               href={`https://github.com/SSWConsulting/SSW.Rules.Content/blob/main/rules/${rule?.uri}/rule.md`}
-              target='_blank'
-              children={<RiGithubLine size={ICON_SIZE} className='rule-icon' />}
+              target="_blank"
+              children={<RiGithubLine size={ICON_SIZE} className="rule-icon" />}
             />
           </div>
         )}

--- a/components/rule-list/rule-list-item-header.tsx
+++ b/components/rule-list/rule-list-item-header.tsx
@@ -9,34 +9,34 @@ import { ICON_SIZE } from '@/constants';
 import { useUser } from '@auth0/nextjs-auth0';
 
 export interface RuleListItemHeaderProps {
-    rule: {
-        guid: string;
-        title: string;
-        uri: string;
-        isBookmarked: boolean;
-    };
-    showBookmark?: boolean;
-    onBookmarkRemoved?: (ruleGuid: string) => void;
-    index: number;
+  rule: {
+    guid: string;
+    title: string;
+    uri: string;
+    isBookmarked: boolean;
+  };
+  showBookmark?: boolean;
+  onBookmarkRemoved?: (ruleGuid: string) => void;
+  index: number;
 }
 
 const RuleListItemHeader: React.FC<RuleListItemHeaderProps> = ({ rule, showBookmark = false, onBookmarkRemoved, index }) => {
-    const linkRef = useRef<HTMLAnchorElement>(null);
-    const [isBookmarked, setIsBookmarked] = useState<boolean>(rule.isBookmarked);
-     const { user } = useUser();
-    const [isRemoving, setIsRemoving] = useState(false);
+  const linkRef = useRef<HTMLAnchorElement>(null);
+  const [isBookmarked, setIsBookmarked] = useState<boolean>(rule.isBookmarked);
+  const { user } = useUser();
+  const [isRemoving, setIsRemoving] = useState(false);
 
-    useEffect(() => {
-        setIsBookmarked(rule.isBookmarked);
-    }, [rule.isBookmarked]);
+  useEffect(() => {
+    setIsBookmarked(rule.isBookmarked);
+  }, [rule.isBookmarked]);
 
-    const handleBookmarkToggle = async (newStatus: boolean) => {
-        setIsBookmarked(newStatus);
-    };
+  const handleBookmarkToggle = async (newStatus: boolean) => {
+    setIsBookmarked(newStatus);
+  };
 
-      const handleRemoveBookmark = async (ruleGuid: string) => {
+  const handleRemoveBookmark = async (ruleGuid: string) => {
     if (!user?.sub) return;
-    
+
     setIsRemoving(true);
     try {
       if (onBookmarkRemoved) {
@@ -49,32 +49,32 @@ const RuleListItemHeader: React.FC<RuleListItemHeaderProps> = ({ rule, showBookm
     }
   };
 
-    return (
-        <section className='mb-2'>
-            <div className='flex items-center flex-col justify-between sm:flex-row'>
-                <div className='flex items-center gap-4 md:gap-2'>
-                    <span className='text-sm text-gray-500'>#{index + 1}</span>
-                    <h2 className='m-0 text-2xl'>
-                        <Link href={`../${rule.uri}`} ref={linkRef} className='no-underline'>
-                            {rule.title}
-                        </Link>
-                    </h2>
-                </div>
+  return (
+    <section>
+      <div className='mt-2 flex items-center flex-col justify-between sm:flex-row'>
+        <div className='flex gap-4 md:gap-2 md:mr-2'>
+          <span className='text-sm text-gray-500'>#{index + 1}</span>
+          <h2 className='m-0 text-2xl'>
+            <Link href={`../${rule.uri}`} ref={linkRef} className='no-underline'>
+              {rule.title}
+            </Link>
+          </h2>
+        </div>
 
-                {showBookmark && (
-                    <div className='profile-rule-buttons flex gap-3 justify-center mt-4 md:mt-0'>
-                        <Bookmark ruleGuid={rule.guid} isBookmarked={isBookmarked} onBookmarkToggle={handleBookmarkToggle} />
-                        <IconLink href={`./admin#/~/${rule?.uri}`} children={<RiPencilLine size={ICON_SIZE} />} />
-                        <IconLink
-                            href={`https://github.com/SSWConsulting/SSW.Rules.Content/blob/main/rules/${rule?.uri}/rule.md`}
-                            target='_blank'
-                            children={<RiGithubLine size={ICON_SIZE} className='rule-icon' />}
-                        />
-                    </div>
-                )}
-            </div>
-        </section>
-    );
+        {showBookmark && (
+          <div className='profile-rule-buttons flex gap-3 justify-center mt-4 md:mt-0'>
+            <Bookmark ruleGuid={rule.guid} isBookmarked={isBookmarked} onBookmarkToggle={handleBookmarkToggle} />
+            <IconLink href={`./admin#/~/${rule?.uri}`} children={<RiPencilLine size={ICON_SIZE} />} />
+            <IconLink
+              href={`https://github.com/SSWConsulting/SSW.Rules.Content/blob/main/rules/${rule?.uri}/rule.md`}
+              target='_blank'
+              children={<RiGithubLine size={ICON_SIZE} className='rule-icon' />}
+            />
+          </div>
+        )}
+      </div>
+    </section>
+  );
 };
 
 export default RuleListItemHeader;

--- a/components/rule-list/rule-list-item.tsx
+++ b/components/rule-list/rule-list-item.tsx
@@ -38,10 +38,10 @@ const RuleListItem: React.FC<RuleListItemProps> = ({ rule, index, filter, onBook
   }
 
   return (
-    <li key={index} className='p-4 pt-5 border rounded shadow'>
+    <li key={index} className="p-4 pt-5 border rounded shadow">
       <RuleListItemHeader rule={rule} index={index} showBookmark={true} onBookmarkRemoved={onBookmarkRemoved} />
 
-      <div data-tina-field={tinaField(rule, 'body')} className='px-2 py-2 md:px-6 md:pt-4 md:pl-4 md:pr-4 md:pb-0'>
+      <div data-tina-field={tinaField(rule, 'body')} className="px-2 py-2 md:px-6 md:pt-4 md:pl-4 md:pr-4 md:pb-0">
         <TinaMarkdown content={getContentForViewStyle(filter, rule.body)} components={MarkdownComponentMapping} />
       </div>
     </li>

--- a/components/rule-list/rule-list-item.tsx
+++ b/components/rule-list/rule-list-item.tsx
@@ -8,43 +8,43 @@ import MarkdownComponentMapping from '../tina-markdown/markdown-component-mappin
 import { RuleListFilter } from '@/types/ruleListFilter';
 
 export interface RuleListItemProps {
-    rule: any;
-    index: number;
-    filter: RuleListFilter;
-    onBookmarkRemoved?: (ruleGuid: string) => void;
+  rule: any;
+  index: number;
+  filter: RuleListFilter;
+  onBookmarkRemoved?: (ruleGuid: string) => void;
 }
 
 const RuleListItem: React.FC<RuleListItemProps> = ({ rule, index, filter, onBookmarkRemoved }) => {
-    function collectIntroEmbeds(nodes: any[] = []): any[] {
-        const out: any[] = [];
-        for (const n of nodes) {
-            if (n?.name === 'introEmbed') out.push(n);
-            if (Array.isArray(n?.children)) out.push(...collectIntroEmbeds(n.children));
-        }
-        return out;
+  function collectIntroEmbeds(nodes: any[] = []): any[] {
+    const out: any[] = [];
+    for (const n of nodes) {
+      if (n?.name === 'introEmbed') out.push(n);
+      if (Array.isArray(n?.children)) out.push(...collectIntroEmbeds(n.children));
     }
+    return out;
+  }
 
-    function makeBlurbContent(body?: any) {
-        const children = Array.isArray(body?.children) ? body.children : [];
-        const embeds = collectIntroEmbeds(children);
-        return { type: 'root', children: embeds };
-    }
+  function makeBlurbContent(body?: any) {
+    const children = Array.isArray(body?.children) ? body.children : [];
+    const embeds = collectIntroEmbeds(children);
+    return { type: 'root', children: embeds };
+  }
 
-    function getContentForViewStyle(filter: RuleListFilter, body?: any) {
-        if (!body) return undefined;
-        if (filter === RuleListFilter.All) return body;
-        if (filter === RuleListFilter.Blurb) return makeBlurbContent(body);
-        return undefined;
-    }
+  function getContentForViewStyle(filter: RuleListFilter, body?: any) {
+    if (!body) return undefined;
+    if (filter === RuleListFilter.All) return body;
+    if (filter === RuleListFilter.Blurb) return makeBlurbContent(body);
+    return undefined;
+  }
 
-    return (
-        <li key={index} className='p-4 pt-5 border rounded shadow'>
-            <RuleListItemHeader rule={rule} index={index} showBookmark={true} onBookmarkRemoved={onBookmarkRemoved}/>
+  return (
+    <li key={index} className='p-4 pt-5 border rounded shadow'>
+      <RuleListItemHeader rule={rule} index={index} showBookmark={true} onBookmarkRemoved={onBookmarkRemoved} />
 
-            <div data-tina-field={tinaField(rule, 'body')} className='px-2 py-2 md:px-6 md:py-4'>
-                <TinaMarkdown content={getContentForViewStyle(filter, rule.body)} components={MarkdownComponentMapping} />
-            </div>
-        </li>
-    );
+      <div data-tina-field={tinaField(rule, 'body')} className='px-2 py-2 md:px-6 md:pt-4 md:pl-4 md:pr-4 md:pb-0'>
+        <TinaMarkdown content={getContentForViewStyle(filter, rule.body)} components={MarkdownComponentMapping} />
+      </div>
+    </li>
+  );
 };
 export default RuleListItem;

--- a/components/rule-list/rule-list.tsx
+++ b/components/rule-list/rule-list.tsx
@@ -16,13 +16,7 @@ export interface RuleListProps {
   onBookmarkRemoved?: (ruleGuid: string) => void;
 }
 
-const RuleList: React.FC<RuleListProps> = ({
-  categoryUri,
-  rules,
-  type,
-  noContentMessage,
-  onBookmarkRemoved,
-}) => {
+const RuleList: React.FC<RuleListProps> = ({ categoryUri, rules, type, noContentMessage, onBookmarkRemoved }) => {
   const [filter, setFilter] = useState<RuleListFilter>(RuleListFilter.Blurb);
 
   const handleOptionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -31,63 +25,45 @@ const RuleList: React.FC<RuleListProps> = ({
 
   if (rules.length === 0) {
     return (
-      <div className='flex items-center justify-center min-h-[400px]'>
-        <p className='text-xl text-gray-600'>{noContentMessage || 'No rules found.'}</p>
+      <div className="flex items-center justify-center min-h-[400px]">
+        <p className="text-xl text-gray-600">{noContentMessage || 'No rules found.'}</p>
       </div>
     );
   }
 
   return (
     <>
-      <div className='flex flex-col-reverse justify-between items-center mt-2 sm:flex-row sm:mt-0'>
-        <div className='flex gap-2 items-center py-4 text-center lg:grid-cols-5'>
+      <div className="flex flex-col-reverse justify-between items-center mt-2 sm:flex-row sm:mt-0">
+        <div className="flex gap-2 items-center py-4 text-center lg:grid-cols-5">
           <RadioButton
-            id='customRadioInline1'
-            value='titleOnly'
+            id="customRadioInline1"
+            value="titleOnly"
             selectedOption={filter}
             handleOptionChange={handleOptionChange}
-            labelText='View titles only'
+            labelText="View titles only"
           />
-          <RadioButton
-            id='customRadioInline2'
-            value='all'
-            selectedOption={filter}
-            handleOptionChange={handleOptionChange}
-            labelText='Show all'
-          />
-          <RadioButton
-            id='customRadioInline3'
-            value='blurb'
-            selectedOption={filter}
-            handleOptionChange={handleOptionChange}
-            labelText='Show blurb'
-          />
-          <p className='mx-3 hidden sm:block'>{rules.length} Rules</p>
+          <RadioButton id="customRadioInline2" value="all" selectedOption={filter} handleOptionChange={handleOptionChange} labelText="Show all" />
+          <RadioButton id="customRadioInline3" value="blurb" selectedOption={filter} handleOptionChange={handleOptionChange} labelText="Show blurb" />
+          <p className="mx-3 hidden sm:block">{rules.length} Rules</p>
         </div>
         {type === 'category' && (
-          <div className='flex gap-2'>
+          <div className="flex gap-2">
             <IconLink
               href={`admin/index.html#/collections/edit/category/${categoryUri?.slice(0, -4)}`}
               children={<RiPencilLine size={ICON_SIZE} />}
             />
             <IconLink
               href={`https://github.com/SSWConsulting/SSW.Rules.Content/blob/${process.env.NEXT_PUBLIC_TINA_BRANCH}/categories/${categoryUri}`}
-              target='_blank'
-              children={<RiGithubLine size={ICON_SIZE} className='rule-icon' />}
+              target="_blank"
+              children={<RiGithubLine size={ICON_SIZE} className="rule-icon" />}
             />
           </div>
         )}
       </div>
 
-      <ol className='flex flex-col justify-between gap-4 p-0 list-none'>
+      <ol className="flex flex-col justify-between gap-4 p-0 list-none">
         {rules.map((rule, i) => (
-          <RuleListItem
-            key={`${rule.guid}-${rule.uri}`}
-            rule={rule}
-            index={i}
-            onBookmarkRemoved={onBookmarkRemoved}
-            filter={filter}
-          />
+          <RuleListItem key={`${rule.guid}-${rule.uri}`} rule={rule} index={i} onBookmarkRemoved={onBookmarkRemoved} filter={filter} />
         ))}
       </ol>
     </>

--- a/components/rule-list/rule-list.tsx
+++ b/components/rule-list/rule-list.tsx
@@ -16,59 +16,73 @@ export interface RuleListProps {
   onBookmarkRemoved?: (ruleGuid: string) => void;
 }
 
-const RuleList: React.FC<RuleListProps> = ({ categoryUri, rules, type, noContentMessage, onBookmarkRemoved }) => {
+const RuleList: React.FC<RuleListProps> = ({
+  categoryUri,
+  rules,
+  type,
+  noContentMessage,
+  onBookmarkRemoved,
+}) => {
   const [filter, setFilter] = useState<RuleListFilter>(RuleListFilter.Blurb);
 
   const handleOptionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFilter(e.target.value as RuleListFilter);
   };
 
-  if(rules.length === 0){
-    return <div className="flex items-center justify-center min-h-[400px]">
-      <p className="text-xl text-gray-600">
-        {noContentMessage || 'No rules found.'}
-      </p>
-    </div>;
+  if (rules.length === 0) {
+    return (
+      <div className='flex items-center justify-center min-h-[400px]'>
+        <p className='text-xl text-gray-600'>{noContentMessage || 'No rules found.'}</p>
+      </div>
+    );
   }
 
   return (
     <>
-    <div className='flex justify-between items-center'>
-      <div className="flex gap-2 items-center py-4 text-center lg:grid-cols-5">
-        <RadioButton
-          id="customRadioInline2"
-          name="customRadioInline1"
-          value="all"
-          selectedOption={filter}
-          handleOptionChange={handleOptionChange}
-          labelText="Show all" />
-        <RadioButton
-          id="customRadioInline3"
-          name="customRadioInline1"
-          value="blurb"
-          selectedOption={filter}
-          handleOptionChange={handleOptionChange}
-          labelText="Show blurb" />
-        <p className='mx-3 hidden sm:block'>{rules.length} Rules</p>
-      </div>
-      {type === 'category' && (
-        <div className='flex gap-2'>
-          <IconLink
-            href={`admin/index.html#/collections/edit/category/${categoryUri?.slice(0, -4)}`}
-            children={<RiPencilLine size={ICON_SIZE} />}
+      <div className='flex flex-col-reverse justify-between items-center mt-2 sm:flex-row sm:mt-0'>
+        <div className='flex gap-2 items-center py-4 text-center lg:grid-cols-5'>
+          <RadioButton
+            id='customRadioInline1'
+            value='titleOnly'
+            selectedOption={filter}
+            handleOptionChange={handleOptionChange}
+            labelText='View titles only'
           />
-          <IconLink 
-            href={`https://github.com/SSWConsulting/SSW.Rules.Content/blob/${process.env.NEXT_PUBLIC_TINA_BRANCH}/categories/${categoryUri}`} target="_blank"
-            children={<RiGithubLine size={ICON_SIZE} className="rule-icon" />}
+          <RadioButton
+            id='customRadioInline2'
+            value='all'
+            selectedOption={filter}
+            handleOptionChange={handleOptionChange}
+            labelText='Show all'
           />
+          <RadioButton
+            id='customRadioInline3'
+            value='blurb'
+            selectedOption={filter}
+            handleOptionChange={handleOptionChange}
+            labelText='Show blurb'
+          />
+          <p className='mx-3 hidden sm:block'>{rules.length} Rules</p>
         </div>
-      )}
-    </div>
-      
-      <ol className="flex flex-col justify-between gap-4 p-0 list-none">
+        {type === 'category' && (
+          <div className='flex gap-2'>
+            <IconLink
+              href={`admin/index.html#/collections/edit/category/${categoryUri?.slice(0, -4)}`}
+              children={<RiPencilLine size={ICON_SIZE} />}
+            />
+            <IconLink
+              href={`https://github.com/SSWConsulting/SSW.Rules.Content/blob/${process.env.NEXT_PUBLIC_TINA_BRANCH}/categories/${categoryUri}`}
+              target='_blank'
+              children={<RiGithubLine size={ICON_SIZE} className='rule-icon' />}
+            />
+          </div>
+        )}
+      </div>
+
+      <ol className='flex flex-col justify-between gap-4 p-0 list-none'>
         {rules.map((rule, i) => (
           <RuleListItem
-           key={`${rule.guid}-${rule.uri}`}
+            key={`${rule.guid}-${rule.uri}`}
             rule={rule}
             index={i}
             onBookmarkRemoved={onBookmarkRemoved}


### PR DESCRIPTION
## Description

Adding the missing 3rd button "Show only titles", and adjust the number of categories with title.

## Screenshot (optional)

<img width="1910" height="916" alt="image" src="https://github.com/user-attachments/assets/b6cc80f4-03cb-428a-996a-8cec5a3cde6c" />

**Figure: 3rd button and alignement of number are present**

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->