### PR TITLE
Small wording and order changes in Category Page

### DIFF
--- a/components/rule-list/rule-list.tsx
+++ b/components/rule-list/rule-list.tsx
@@ -40,10 +40,10 @@ const RuleList: React.FC<RuleListProps> = ({ categoryUri, rules, type, noContent
             value="titleOnly"
             selectedOption={filter}
             handleOptionChange={handleOptionChange}
-            labelText="View titles only"
+            labelText="Title"
           />
-          <RadioButton id="customRadioInline2" value="all" selectedOption={filter} handleOptionChange={handleOptionChange} labelText="Show all" />
-          <RadioButton id="customRadioInline3" value="blurb" selectedOption={filter} handleOptionChange={handleOptionChange} labelText="Show blurb" />
+          <RadioButton id="customRadioInline3" value="blurb" selectedOption={filter} handleOptionChange={handleOptionChange} labelText="Blurbs" />
+          <RadioButton id="customRadioInline2" value="all" selectedOption={filter} handleOptionChange={handleOptionChange} labelText="Everythings" />
           <p className="mx-3 hidden sm:block">{rules.length} Rules</p>
         </div>
         {type === 'category' && (


### PR DESCRIPTION
## Description

Small wording and order changes in Category Page

## Screenshot (optional)

<img width="2550" height="1245" alt="image" src="https://github.com/user-attachments/assets/eae0c489-f6db-4a68-81b1-1e3004c9e4c4" />

**Figure: Category view in desktop**

<img width="474" height="1026" alt="image" src="https://github.com/user-attachments/assets/5e1040b6-6213-4d24-990d-66379af8623d" />

**Figure: Category view in mobile**

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->