### PR TITLE
Return empty array when category has no rules

### DIFF
--- a/app/[filename]/client-category-page.tsx
+++ b/app/[filename]/client-category-page.tsx
@@ -30,7 +30,6 @@ export default function ClientCategoryPage(props: ClientCategoryPageProps) {
 
   const { user, isLoading: authLoading } = useAuth();
   const category = data?.category;
-  console.log(category);
   const baseRules = useMemo(() => {
     if (!category?.index) return [];
     return category.index.flatMap((i) => Array.isArray(i?.rule) ? i.rule : []);

--- a/app/[filename]/client-category-page.tsx
+++ b/app/[filename]/client-category-page.tsx
@@ -31,7 +31,8 @@ export default function ClientCategoryPage(props: ClientCategoryPageProps) {
   const { user, isLoading: authLoading } = useAuth();
   const category = data?.category;
   const baseRules = useMemo(() => {
-    return category?.index.flatMap((i) => i.rule) || [];
+    if (!category?.index) return [];
+    return category.index.flatMap((i) => i?.rule ?? []);
   }, [category]);
   const [annotatedRules, setAnnotatedRules] = useState<any[]>([]);
   const [rightSidebarRules, setRightSidebarRules] = useState<any[]>([]);

--- a/app/[filename]/client-category-page.tsx
+++ b/app/[filename]/client-category-page.tsx
@@ -32,7 +32,7 @@ export default function ClientCategoryPage(props: ClientCategoryPageProps) {
   const category = data?.category;
   const baseRules = useMemo(() => {
     if (!category?.index) return [];
-    return category.index.flatMap((i) => i?.rule ?? []);
+    return category.index.flatMap((i) => Array.isArray(i?.rule) ? i.rule : []);
   }, [category]);
   const [annotatedRules, setAnnotatedRules] = useState<any[]>([]);
   const [rightSidebarRules, setRightSidebarRules] = useState<any[]>([]);

--- a/app/[filename]/client-category-page.tsx
+++ b/app/[filename]/client-category-page.tsx
@@ -30,6 +30,7 @@ export default function ClientCategoryPage(props: ClientCategoryPageProps) {
 
   const { user, isLoading: authLoading } = useAuth();
   const category = data?.category;
+  console.log(category);
   const baseRules = useMemo(() => {
     if (!category?.index) return [];
     return category.index.flatMap((i) => Array.isArray(i?.rule) ? i.rule : []);

--- a/app/client-page.tsx
+++ b/app/client-page.tsx
@@ -28,7 +28,7 @@ export default function HomeClientPage(props: HomeClientPageProps) {
     return subCategories.map((item: any) => {
       const filename = item.category?._sys.filename;
       return filename ? categoryRuleCounts[filename] || 0 : 0;
-    }).reduce((sum, count) => sum + count, 0)
+    }).reduce((sum, count) => sum + count, 0);
   };
 
   return (

--- a/app/client-page.tsx
+++ b/app/client-page.tsx
@@ -25,9 +25,10 @@ export default function HomeClientPage(props: HomeClientPageProps) {
   const topCategoriesWithoutChildren = topCategories.filter(c => !c.index);
 
   const getTopCategoryTotal = (subCategories: any[]) => {
-    return subCategories.reduce((total, category) => {
-      return total + (categoryRuleCounts[category._sys.filename] || 0);
-    }, 0);
+    return subCategories.map((item: any) => {
+      const filename = item.category?._sys.filename;
+      return filename ? categoryRuleCounts[filename] || 0 : 0;
+    }).reduce((sum, count) => sum + count, 0)
   };
 
   return (
@@ -40,15 +41,7 @@ export default function HomeClientPage(props: HomeClientPageProps) {
           </div>
 
           {topCategoriesWithChildren.map((topCategory, index) => {
-            // Calculate total rules across all categories inside this top category
-            const totalRules = (topCategory.index || [])
-              .map((item: any) => {
-                const filename = item.category?._sys.filename;
-                return filename ? categoryRuleCounts[filename] || 0 : 0;
-              })
-              .reduce((sum, count) => sum + count, 0);
-
-            // Skip rendering this top category if it has no rules
+            const totalRules = getTopCategoryTotal(topCategory.index || []);
             if (totalRules === 0) {
               return null;
             }

--- a/app/client-page.tsx
+++ b/app/client-page.tsx
@@ -21,8 +21,11 @@ export interface HomeClientPageProps {
 
 export default function HomeClientPage(props: HomeClientPageProps) {
   const { topCategories, latestRules, ruleCount, categoryRuleCounts } = props;
+  const topCategoriesWithChildren = topCategories.filter(c => c.index);
+  const topCategoriesWithoutChildren = topCategories.filter(c => !c.index);
 
   const getTopCategoryTotal = (subCategories: any[]) => {
+    console.log(categoryRuleCounts);
     return subCategories.reduce((total, category) => {
       return total + (categoryRuleCounts[category._sys.filename] || 0);
     }, 0);
@@ -37,38 +40,53 @@ export default function HomeClientPage(props: HomeClientPageProps) {
             <h2 className="m-0 mb-4 text-ssw-red font-bold">Categories</h2>
           </div>
 
-          {topCategories.map((topCategory, index) => (
-            <Card key={index} className="mb-4">
-              <h2 className="flex justify-between m-0 mb-4 text-2xl max-sm:text-lg">
-                <span>{topCategory.title}</span>
-                <span className="text-gray-500 text-lg">
-                  {getTopCategoryTotal(
-                    topCategory.index
-                      ?.map((item: any) => item.category)
-                      .filter(Boolean) || []
-                  )}{" "}
-                  Rules
-                </span>
-              </h2>
+          {topCategoriesWithChildren.map((topCategory, index) => {
+            // Calculate total rules across all categories inside this top category
+            const totalRules = (topCategory.index || [])
+              .map((item: any) => {
+                const filename = item.category?._sys.filename;
+                return filename ? categoryRuleCounts[filename] || 0 : 0;
+              })
+              .reduce((sum, count) => sum + count, 0);
 
-              <ol>
-                {topCategory.index?.map((item: any, subIndex: number) =>
-                  item.category ? (
-                    <li key={subIndex} className="mb-4">
-                      <div className=" flex justify-between">
-                        <Link href={`/${item.category._sys.filename}`}>
-                          {item.category.title}
-                        </Link>
-                        <span className="text-gray-300">
-                          {categoryRuleCounts[item.category._sys.filename] || 0}
-                        </span>
-                      </div>
-                    </li>
-                  ) : null
-                )}
-              </ol>
-            </Card>
-          ))}
+            // Skip rendering this top category if it has no rules
+            if (totalRules === 0) {
+              return null;
+            }
+
+            return (
+              <Card key={index} className="mb-4">
+                <h2 className="flex justify-between m-0 mb-4 text-2xl max-sm:text-lg">
+                  <span>{topCategory.title}</span>
+                  <span className="text-gray-500 text-lg">
+                    {totalRules} Rules
+                  </span>
+                </h2>
+
+                <ol>
+                  {topCategory.index?.map((item: any, subIndex: number) => {
+                    const filename = item.category?._sys.filename;
+                    const count = categoryRuleCounts[filename] || 0;
+
+                    if (!item.category || count === 0) {
+                      return null;
+                    }
+
+                    return (
+                      <li key={subIndex} className="mb-4">
+                        <div className="flex justify-between">
+                          <Link href={`/${filename}`}>
+                            {item.category.title}
+                          </Link>
+                          <span className="text-gray-300">{count}</span>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ol>
+              </Card>
+            );
+          })}
         </div>
 
         <div className="layout-sidebar">

--- a/app/client-page.tsx
+++ b/app/client-page.tsx
@@ -25,7 +25,6 @@ export default function HomeClientPage(props: HomeClientPageProps) {
   const topCategoriesWithoutChildren = topCategories.filter(c => !c.index);
 
   const getTopCategoryTotal = (subCategories: any[]) => {
-    console.log(categoryRuleCounts);
     return subCategories.reduce((total, category) => {
       return total + (categoryRuleCounts[category._sys.filename] || 0);
     }, 0);


### PR DESCRIPTION
## Description
Hitting a runtime error when a category exists without any rules.
Updated to:
1. Not display any categories that have 0 rules.
2. Not display any top categories that have 0 categories

From:
<img width="1888" height="1719" alt="image" src="https://github.com/user-attachments/assets/7a09271c-de59-4914-9972-7d86bc79fe61" />

To:
<img width="1861" height="1604" alt="image" src="https://github.com/user-attachments/assets/0c7913d3-2217-4bd7-92d7-ea9285226c6b" />

Extra - Not showing Top Category if no category with rules:
<img width="1847" height="1564" alt="image" src="https://github.com/user-attachments/assets/22a82ce6-bc52-46bd-963a-716d80a2c287" />
