### PR TITLE
🐛Fix highlight inside list items

### DIFF
--- a/app/[filename]/client-rule-page.tsx
+++ b/app/[filename]/client-rule-page.tsx
@@ -5,15 +5,13 @@ import { tinaField, useTina } from "tinacms/dist/react";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
 import Image from "next/image";
 import {
-  RiThumbUpLine,
-  RiThumbDownLine,
   RiPencilLine,
   RiGithubLine,
   RiHistoryLine,
 } from "react-icons/ri";
 import Bookmark from "@/components/Bookmark";
 import Link from "next/link";
-import { useMemo, useState, useEffect } from "react";
+import { useMemo, useState, useEffect, useRef } from "react";
 import { formatDateLong, timeAgo } from "@/lib/dateUtils";
 import MarkdownComponentMapping from "@/components/tina-markdown/markdown-component-mapping";
 import HelpCard from "@/components/HelpCard";
@@ -26,6 +24,7 @@ import { getRuleLastModifiedFromAuthors } from "@/lib/services/github";
 import { ICON_SIZE } from "@/constants";
 import Breadcrumbs from "@/components/Breadcrumbs";
 import { useAuth } from "@/components/auth/UserClientProvider";
+import { useMarkHighlight } from "@/lib/useMarkHighlight";
 
 export interface ClientRulePageProps {
   ruleQueryProps;
@@ -39,7 +38,6 @@ export default function ClientRulePage(props: ClientRulePageProps) {
   const [isBookmarked, setIsBookmarked] = useState<boolean>(false);
   const [authorUsername, setAuthorUsername] = useState<string | null>(null);
   const relatedRules = props.relatedRulesMapping || [];
-
   const router = useRouter();
   const [isLoadingUsername, setIsLoadingUsername] = useState(false);
   const ruleData = useTina({
@@ -60,6 +58,9 @@ export default function ClientRulePage(props: ClientRulePageProps) {
       : "Unknown";
     return `Created ${created}\nLast Updated ${updated}`;
   }, [rule?.created, rule?.lastUpdated]);
+
+  const contentRef = useRef<HTMLDivElement>(null);
+  useMarkHighlight(contentRef, "ul li div");
 
   const openUserRule = async (ruleUri: string) => {
     if (!ruleUri) return;
@@ -254,11 +255,11 @@ export default function ClientRulePage(props: ClientRulePageProps) {
               </div>
             </div>
           )}
-          <div data-tina-field={tinaField(rule, "body")} className="mt-8">
-            <TinaMarkdown
-              content={rule?.body}
-              components={MarkdownComponentMapping}
-            />
+          <div data-tina-field={tinaField(rule, "body")} className="mt-8" ref={contentRef}>
+              <TinaMarkdown
+                content={rule?.body}
+                components={MarkdownComponentMapping}
+              />
           </div>
           <div className="hidden md:block">
             <hr className="my-6 mx-0"/>

--- a/components/embeds/asideEmbed.tsx
+++ b/components/embeds/asideEmbed.tsx
@@ -6,6 +6,7 @@ import {
   withFigureEmbedTemplateFields,
 } from "./componentWithFigure";
 import { CodeXml, Info } from "lucide-react";
+import MarkdownComponentMapping from "../tina-markdown/markdown-component-mapping";
 
 type AsideVariant =
   | "greybox"
@@ -74,7 +75,7 @@ export function AsideEmbed({ data }: { data: any }) {
             <div className="flex items-start">
             {config.icon}
             <div className={`prose prose-sm max-w-none text-base ${config.textClass ?? ""}`}>
-                <TinaMarkdown content={data.body} />
+                <TinaMarkdown content={data.body} components={MarkdownComponentMapping} />
             </div>
             </div>
         </div>

--- a/components/embeds/emailEmbed.tsx
+++ b/components/embeds/emailEmbed.tsx
@@ -1,10 +1,12 @@
 import { Template } from "tinacms";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
-import React from "react";
+import React, { useRef } from "react";
 import {
   ComponentWithFigure,
   withFigureEmbedTemplateFields,
 } from "./componentWithFigure";
+import MarkdownComponentMapping from "../tina-markdown/markdown-component-mapping";
+import { useMarkHighlight } from "@/lib/useMarkHighlight";
 
 export function EmailEmbed({ data }: { data: any }) {
   const fields = [
@@ -14,6 +16,9 @@ export function EmailEmbed({ data }: { data: any }) {
     { label: "Bcc", value: data.bcc },
     { label: "Subject", value: data.subject },
   ].filter((field) => field.value?.trim());
+
+  const contentRef = useRef<HTMLDivElement>(null);
+  useMarkHighlight(contentRef, "ol li div");
 
   return (
     <ComponentWithFigure data={data}>
@@ -33,8 +38,8 @@ export function EmailEmbed({ data }: { data: any }) {
 
         <div className="mt-6 pl-24">
           <div className="bg-white border p-4 rounded">
-            <div className="prose prose-sm">
-              <TinaMarkdown content={data.body} />
+            <div className="prose prose-sm" ref={contentRef}>
+              <TinaMarkdown content={data.body} components={MarkdownComponentMapping} />
             </div>
           </div>
         </div>

--- a/lib/useMarkHighlight.tsx
+++ b/lib/useMarkHighlight.tsx
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+
+export function useMarkHighlight(
+  rootRef: React.RefObject<HTMLElement>,
+  selector = "ul li div",
+  markClass = "bg-yellow-200 px-1 py-0.5 rounded-sm"
+) {
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    const process = () => {
+      root.querySelectorAll<HTMLElement>(selector).forEach((el) => {
+        if (el.dataset.markProcessed === "1") return;
+        el.innerHTML = el.innerHTML.replace(
+          /==([\s\S]*?)==/g,
+          `<mark class="${markClass}">$1</mark>`
+        );
+        el.dataset.markProcessed = "1";
+      });
+    };
+
+    process();
+    const mo = new MutationObserver(process);
+    mo.observe(root, { childList: true, subtree: true });
+    return () => mo.disconnect();
+  }, [rootRef, selector, markClass]);
+}


### PR DESCRIPTION
## Description
✏️ 
Relates to https://github.com/SSWConsulting/SSW.Rules/issues/1933

Add useMarkHighlight hook to handle highlight syntax inside a component + inside list items

## Screenshot (optional)
✏️ 
<img width="1832" height="1140" alt="image" src="https://github.com/user-attachments/assets/9d559ef5-c1db-4116-b7dc-411cbe89dfa9" />

<img width="1935" height="1388" alt="image" src="https://github.com/user-attachments/assets/6877a9fd-af0d-4be0-b8dd-66e5244850b5" />


<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->