### PR TITLE
Styles - fixing aligment of breadcrumbs and rule count

### DIFF
--- a/components/Breadcrumbs.tsx
+++ b/components/Breadcrumbs.tsx
@@ -66,7 +66,7 @@ export default function Breadcrumbs({
         </a>
 
         <ol className="flex min-w-0 list-none p-0 m-0 flex-col items-start md:flex-row md:items-center">
-          <li className="flex items-center md:h-[1.5em]">
+          <li className="flex items-center mb-0 md:h-[1.5em]">
             <ChevronIcon className="mr-2 block md:hidden" size={18} />
             <Link
               href={siteUrlRelative}
@@ -78,7 +78,7 @@ export default function Breadcrumbs({
 
           {showCategories &&
             categoryList.map((cat, i) => (
-              <li key={i} className="mt-1 flex items-center md:mt-0">
+              <li key={i} className="mt-1 flex items-center mb-0 md:mt-0">
                 <ChevronIcon className="mr-2 md:mx-2 block" size={18} />
                 <Link
                   href={cat.link}
@@ -90,7 +90,7 @@ export default function Breadcrumbs({
             ))}
 
           {!isHomePage && (
-            <li className="mt-1 flex items-center md:mt-0" aria-current="page">
+            <li className="mt-1 flex items-center mb-0 md:mt-0" aria-current="page">
               <ChevronIcon className="mr-2 md:mx-2 block" size={18} />
               <span className="truncate">{tailText}</span>
             </li>

--- a/components/rule-list/rule-list.tsx
+++ b/components/rule-list/rule-list.tsx
@@ -99,7 +99,7 @@ const RuleList: React.FC<RuleListProps> = ({ categoryUri, rules, type, noContent
               <span className="text-gray-700">Include Archived</span>
             </label>
           )}
-          <p className="mx-3 hidden sm:block">{rules.length} Rules</p>
+          <span className="mx-3 hidden sm:block">{rules.length} Rules</span>
         </div>
         {type === 'category' && (
           <div className="hidden md:flex gap-2">


### PR DESCRIPTION
## Description

Noticed alignment issues and fixed it

## Screenshot (optional)

<img width="1651" height="337" alt="image" src="https://github.com/user-attachments/assets/b727419d-dee6-4be8-b80a-1eb5ea68a30f" />

**Figure: Before / After - breadcrumb and rule count**