### PR TITLE
Upgrade Megamenu to hide flag on mobile view

### DIFF
--- a/components/server/MegaMenuWrapper.tsx
+++ b/components/server/MegaMenuWrapper.tsx
@@ -18,6 +18,7 @@ export function MegaMenuWrapper(props) {
             linkComponent={(props) => <CustomLink {...props} className={classNames('unstyled', props.className)} />}
             url='/rules'
             searchUrl='https://www.ssw.com.au/rules'
+            isFlagVisible={false}
         />
     );
 }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react-responsive-modal": "^7.0.0",
     "react-use-measure": "^2.1.7",
     "shiki": "^3.2.2",
-    "ssw.megamenu": "^4.13.2",
+    "ssw.megamenu": "^4.13.3",
     "styled-jsx": "^5.1.6",
     "svg-react-loader": "^0.4.6",
     "tailwind-merge": "^2.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,8 +135,8 @@ importers:
         specifier: ^3.2.2
         version: 3.13.0
       ssw.megamenu:
-        specifier: ^4.13.2
-        version: 4.13.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^4.13.3
+        version: 4.13.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       styled-jsx:
         specifier: ^5.1.6
         version: 5.1.7(@babel/core@7.28.4)(react@18.3.1)
@@ -6261,8 +6261,8 @@ packages:
     peerDependencies:
       sucrase: ^3.35.0
 
-  ssw.megamenu@4.13.2:
-    resolution: {integrity: sha512-YqI9v9Vaeelk075MC9xtEFi5P1/TREqQWECJCyU/LNLjgef5G9xKLMwZOwN8lVrue95mUrqQeJUB0ZFBFti1qg==}
+  ssw.megamenu@4.13.3:
+    resolution: {integrity: sha512-h4lv3HhxnjPoiZj5fNlVunixUXdcbKUuZBuulo14VFD9pqFd+hwVB4pKlmEqbP31L/x7Gh4DALn86NpHxzuHbA==}
     peerDependencies:
       react: ^18.2.0
       react-dom: ^18.2.0
@@ -14085,7 +14085,7 @@ snapshots:
       module-error: 1.0.2
       sucrase: 3.35.0
 
-  ssw.megamenu@4.13.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  ssw.megamenu@4.13.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@headlessui/react': 2.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@heroicons/react': 2.2.0(react@18.3.1)


### PR DESCRIPTION
## Description
✏️ 
Relates to https://github.com/SSWConsulting/SSW.Rules/issues/1920

Upgrade Megamenu to hide flag on mobile view

## Screenshot (optional)
✏️ 
<img width="1083" height="1261" alt="image" src="https://github.com/user-attachments/assets/cd2217ec-9af4-4e60-a882-18fd183a2dde" />


<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->