### PR TITLE
Front - Making footer always stick to the bottom of the viewport

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -39,7 +39,7 @@ export default function RootLayout({
       lang="en"
       className={cn(fontSans.variable, nunito.variable, lato.variable)}
     >
-      <body className="min-h-screen bg-background font-sans antialiased">
+      <body className="min-h-screen bg-background font-sans antialiased flex flex-col">
         <UserClientProvider>
           <SiteLayout>{children}</SiteLayout>
         </UserClientProvider>

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -24,9 +24,11 @@ export default async function Layout({ children, rawPageData }: LayoutProps) {
 
     return (
         <LayoutProvider globalSettings={globalData.global} pageData={rawPageData}>
+            <div className='flex flex-col flex-1'>
                 <Header />
-                <main className='overflow-x-hidden main-container max-sm:p-2'>{children}</main>
+                <main className='flex-1 overflow-x-hidden main-container max-sm:p-2'>{children}</main>
                 <Footer />
+            </div>
         </LayoutProvider>
     );
 }


### PR DESCRIPTION
## Description

Related PBI: https://github.com/SSWConsulting/SSW.Rules/issues/1952

- Changed CSS to have the footer always to at the bottom of the viewport

## Screenshot (optional)

<img width="5121" height="1392" alt="image" src="https://github.com/user-attachments/assets/70c233c1-eed9-431e-b247-60cf7badeab7" />
