### PR TITLE
LatestRules page - loading rules once getting on the page + showing spinner

### DIFF
--- a/app/latest-rules/client-page.tsx
+++ b/app/latest-rules/client-page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import SearchBar from '@/components/SearchBar';
 import RuleCount from '@/components/RuleCount';
 import WhyRulesCard from '@/components/WhyRulesCard';
@@ -10,14 +11,51 @@ import HelpCard from '@/components/HelpCard';
 import LatestRulesList from '@/components/LatestRulesList';
 import { LatestRule } from '@/models/LatestRule';
 import Breadcrumbs from '@/components/Breadcrumbs';
+import Spinner from '@/components/Spinner';
+import client from '@/tina/__generated__/client';
+import { findAuthorUrlForResult } from '@/lib/services/rules';
 
 interface LatestRuleClientPageProps {
   ruleCount: number;
-  latestRulesByUpdated: LatestRule[];
-  latestRulesByCreated: LatestRule[];
+  initialSize: number;
 }
 
-export default function LatestRuleClientPage({ ruleCount, latestRulesByUpdated, latestRulesByCreated }: LatestRuleClientPageProps) {
+export default function LatestRuleClientPage({ ruleCount, initialSize }: LatestRuleClientPageProps) {
+  const [latestRulesByUpdated, setLatestRulesByUpdated] = useState<LatestRule[]>([]);
+  const [latestRulesByCreated, setLatestRulesByCreated] = useState<LatestRule[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchRules = async () => {
+      setIsLoading(true);
+      try {
+        const [updatedRes, createdRes] = await Promise.all([
+          client.queries.latestRulesQuery({ size: initialSize, sortOption: "lastUpdated" }),
+          client.queries.latestRulesQuery({ size: initialSize, sortOption: "created" }),
+        ]);
+
+        const processRules = (res: any) => {
+          const results = res?.data?.ruleConnection?.edges
+            ?.filter((edge: any) => edge && edge.node)
+            .map((edge: any) => edge.node) || [];
+
+          return results.map((r: any) => ({
+            ...r,
+            authorUrl: findAuthorUrlForResult(r),
+          }));
+        };
+
+        setLatestRulesByUpdated(processRules(updatedRes));
+        setLatestRulesByCreated(processRules(createdRes));
+      } catch (error) {
+        console.error('Error fetching latest rules:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchRules();
+  }, [initialSize]);
 
   return (
        <>
@@ -27,14 +65,21 @@ export default function LatestRuleClientPage({ ruleCount, latestRulesByUpdated, 
               <div className="h-[5rem]">
                 <SearchBar />
               </div>
-              
-              <LatestRulesList 
-                rulesByUpdated={latestRulesByUpdated}
-                rulesByCreated={latestRulesByCreated}
-                title="Latest Rules"
-              />
+
+              {isLoading ? (
+                <div className="flex flex-col justify-center items-center min-h-[400px] gap-4">
+                  <Spinner size="xl" />
+                  <p className="text-gray-500 text-lg">Loading latest rules...</p>
+                </div>
+              ) : (
+                <LatestRulesList
+                  rulesByUpdated={latestRulesByUpdated}
+                  rulesByCreated={latestRulesByCreated}
+                  title="Latest Rules"
+                />
+              )}
             </div>
-    
+
             <div className="layout-sidebar">
               <div className="h-[3.5rem]">
                 {ruleCount && <RuleCount count={ruleCount} />}

--- a/app/latest-rules/page.tsx
+++ b/app/latest-rules/page.tsx
@@ -1,7 +1,8 @@
-import Layout from '@/components/layout/layout';
 import { Section } from '@/components/layout/section';
 import LatestRuleClientPage from './client-page';
-import { fetchLatestRules, fetchRuleCount } from '@/lib/services/rules';
+import { fetchRuleCount } from '@/lib/services/rules';
+import { Suspense } from 'react';
+import Spinner from '@/components/Spinner';
 
 export const revalidate = 300;
 
@@ -14,19 +15,16 @@ export default async function LatestRulePage({ searchParams }: LatestRulePagePro
 
   const size = sizeStr ? parseInt(sizeStr, 10) : 5;
 
-  const [latestRulesByUpdated, latestRulesByCreated, ruleCount] = await Promise.all([
-    fetchLatestRules(size, "lastUpdated"),
-    fetchLatestRules(size, "created"),
-    fetchRuleCount(),
-  ]);
+  const ruleCount = await fetchRuleCount();
 
   return (
       <Section>
-        <LatestRuleClientPage 
-          ruleCount={ruleCount}
-          latestRulesByUpdated={latestRulesByUpdated}
-          latestRulesByCreated={latestRulesByCreated}
-        />
+        <Suspense fallback={<Spinner size="lg" />}>
+          <LatestRuleClientPage
+            ruleCount={ruleCount}
+            initialSize={size}
+          />
+        </Suspense>
       </Section>
   );
 }

--- a/components/LatestRulesCard.tsx
+++ b/components/LatestRulesCard.tsx
@@ -2,11 +2,8 @@
 
 import { Card } from "@/components/ui/card";
 import { LatestRule } from "@/models/LatestRule";
-import { useRouter } from "next/navigation";
 import { timeAgo } from "@/lib/dateUtils";
 import { RiTimeFill } from "react-icons/ri";
-import Spinner from "./Spinner";
-import React, { useState, useTransition } from "react";
 import Link from "next/link";
 
 interface LatestRulesProps {
@@ -14,20 +11,6 @@ interface LatestRulesProps {
 }
 
 export default function LatestRulesCard({ rules }: LatestRulesProps) {
-  const router = useRouter();
-  const [loading, setLoading] = useState(false);
-  const [isPending, startTransition] = useTransition();
-
-  const handleSeeMore = (e: React.MouseEvent) => {
-    e.preventDefault();
-    if (loading || isPending) return;
-    setLoading(true);
-    // Start a React transition; isPending will remain true until navigation completes
-    startTransition(() => {
-      router.push("/latest-rules/?size=50");
-    });
-  };
-
   return (
     <Card title="Latest Rules">
       {rules.map((rule, index) => (
@@ -45,14 +28,12 @@ export default function LatestRulesCard({ rules }: LatestRulesProps) {
       ))}
 
       <div>
-        <button
-          onClick={handleSeeMore}
-          disabled={loading || isPending}
-          className={`px-4 py-2 rounded-md inline-flex items-center ${loading || isPending ? 'text-gray-500' : 'text-ssw-red cursor-pointer hover:underline'}`}
+        <Link
+          href="/latest-rules/?size=50"
+          className="px-4 py-2 rounded-md inline-flex items-center text-ssw-red hover:underline"
         >
-          {(loading || isPending) ? <Spinner size="sm" inline className="mr-2" /> : null}
-          <span>{(loading || isPending) ? "Loading..." : "See More"}</span>
-        </button>
+          See More
+        </Link>
       </div>
     </Card>
   );


### PR DESCRIPTION
## Description

Related PBI: https://github.com/SSWConsulting/SSW.Rules/issues/1958

- Fetching latest rules from the page and adding spinner

## Screenshot (optional)

![72612362-0646-4045-9068-0C7BAE30F4E5](https://github.com/user-attachments/assets/fbe5ac2f-d441-48ba-8eb2-b179ef34d113)
