### PR TITLE
Adding "Show Me" in front of the filters in the category page

### DIFF
--- a/components/rule-list/rule-list.tsx
+++ b/components/rule-list/rule-list.tsx
@@ -77,6 +77,7 @@ const RuleList: React.FC<RuleListProps> = ({ categoryUri, rules, type, noContent
       <div ref={filterSectionRef} className="flex flex-col-reverse justify-between items-center mt-2 sm:flex-row sm:mt-0">
         <div className="flex flex-col items-center sm:flex-row sm:items-center gap-2 py-4 text-center lg:grid-cols-5">
           <div className="flex items-center">
+            <span className="mr-4 hidden sm:block">Show Me</span>
             <RadioButton
               id="customRadioInline1"
               value="titleOnly"


### PR DESCRIPTION
## Description

- Added "Show Me" in front of the filters in the category page
- Updated CSS to only show on desktop

## Screenshot (optional)

<img width="1720" height="1380" alt="image" src="https://github.com/user-attachments/assets/5df75b56-247c-44ee-b8f4-93c657072373" />
