### PR TITLE
Use prose-neutral to set text to greyish black instead of blueish black

### DIFF
--- a/components/embeds/asideEmbed.tsx
+++ b/components/embeds/asideEmbed.tsx
@@ -74,7 +74,7 @@ export function AsideEmbed({ data }: { data: any }) {
         <div className={`p-4 rounded-sm my-4 ${config.containerClass}`}>
             <div className="flex items-start">
             {config.icon}
-            <div className={`prose prose-sm max-w-none text-base ${config.textClass ?? ""}`}>
+            <div className={`prose prose-neutral prose-sm max-w-none text-base ${config.textClass ?? ""}`}>
                 <TinaMarkdown content={data.body} components={MarkdownComponentMapping} />
             </div>
             </div>

--- a/components/embeds/emailEmbed.tsx
+++ b/components/embeds/emailEmbed.tsx
@@ -38,7 +38,7 @@ export function EmailEmbed({ data }: { data: any }) {
 
         <div className="mt-6 pl-24">
           <div className="bg-white border p-4 rounded">
-            <div className="prose prose-sm" ref={contentRef}>
+            <div className="prose prose-neutral prose-sm" ref={contentRef}>
               <TinaMarkdown content={data.body} components={MarkdownComponentMapping} />
             </div>
           </div>


### PR DESCRIPTION
<img width="1742" height="1030" alt="image" src="https://github.com/user-attachments/assets/a23032bc-8565-4df4-b280-5d00b8d79143" />
