### PR TITLE
Rules Dropdown - Enable server-side rule search

### DIFF
--- a/app/api/rules/paginated/route.ts
+++ b/app/api/rules/paginated/route.ts
@@ -11,22 +11,19 @@ export async function GET(req: Request) {
 
   const first = firstStr ? Number(firstStr) : undefined;
   const last = lastStr ? Number(lastStr) : undefined;
+  
+  const q = (searchParams.get("q") || "").trim() || undefined;
+  const field = (searchParams.get("field") as "title" | "uri") || undefined;
+  const sort = searchParams.get("sort") || undefined;
 
   try {
-    const result = await fetchPaginatedRules({ first, last, after, before });
+    const result = await fetchPaginatedRules({ first, last, after, before, q, field, sort });
     return NextResponse.json(
-      {
-        items: result.items,
-        pageInfo: result.pageInfo,
-        totalCount: result.totalCount,
-      },
+      { items: result.items, pageInfo: result.pageInfo, totalCount: result.totalCount },
       { status: 200 }
     );
-  } catch (err: any) {
+  } catch (err) {
     console.error("[/api/rules/paginated] error:", err);
-    return NextResponse.json(
-      { message: "Failed to fetch paginated rules" },
-      { status: 500 }
-    );
+    return NextResponse.json({ message: "Failed to fetch paginated rules" }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Description
✏️ 
Relates to https://github.com/SSWConsulting/SSW.Rules/issues/2006

This update moves the rule search logic from client-side filtering to server-side filtering, using Tina’s GraphQL query with pagination support.

## Screenshot (optional)
✏️ 
<img width="1712" height="759" alt="image" src="https://github.com/user-attachments/assets/6b1b8254-99cc-4db7-9b32-a4b93b042c0d" />


<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->