### PR TITLE
Adjusts index label width for consistent alignment

### DIFF
--- a/components/rule-list/rule-list-item-header.tsx
+++ b/components/rule-list/rule-list-item-header.tsx
@@ -57,7 +57,7 @@ const RuleListItemHeader: React.FC<RuleListItemHeaderProps> = ({ rule, showBookm
         </div>
 
         {showBookmark && (
-          <div className="profile-rule-buttons flex gap-3 justify-center self-start mt-4 md:mt-0">
+          <div className="profile-rule-buttons hidden md:flex gap-3 justify-center self-start mt-4 md:mt-0">
             <Bookmark ruleGuid={rule.guid} isBookmarked={isBookmarked} onBookmarkToggle={handleBookmarkToggle} />
             <IconLink
               href={`/admin#/~/${sanitizedBasePath}/${rule?.uri}`}


### PR DESCRIPTION
## Description
✏️ 
Relates to https://github.com/SSWConsulting/SSW.Rules/issues/2023#issuecomment-3424191565

Add the class w-6 to the <span> that contains the rule number

## Screenshot (optional)
✏️ 
<img width="1821" height="1421" alt="image" src="https://github.com/user-attachments/assets/e5e30867-ccac-48ef-8522-9dd917b63f20" />

<img width="2220" height="1559" alt="image" src="https://github.com/user-attachments/assets/ec6d042b-bb7f-4ce2-8bc4-78cfaa07d3c8" />





<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->