### PR TITLE
Fixing issue with tooltips

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -38,7 +38,6 @@ export default function RootLayout({
     <html
       lang="en"
       className={cn(fontSans.variable, nunito.variable, lato.variable)}
-      title="SSW Rules | Secret Ingredients for Quality Software (Open Source on GitHub)"
     >
       <body className="min-h-screen bg-background font-sans antialiased flex flex-col">
         <UserClientProvider>


### PR DESCRIPTION
Fixed: [#2042](https://github.com/SSWConsulting/SSW.Rules/issues/2042)

## Description
✏️ Remove title attribute from the DOC element to prevent it from showing as a tooltip across the entire page.