### PR TITLE
CSS - updating link style to just use tailwind underline class

### DIFF
--- a/app/[filename]/client-rule-page.tsx
+++ b/app/[filename]/client-rule-page.tsx
@@ -169,7 +169,7 @@ export default function ClientRulePage(props: ClientRulePageProps) {
                   {rule?.lastUpdatedBy ? (
                     authorUsername ? (
                       <Link href={`./user?author=${encodeURIComponent(authorUsername)}`}
-                        className="font-semibold ssw-link"
+                        className="font-semibold underline"
                         title={`View ${rule.lastUpdatedBy}'s rules`}
                       >
                         {rule.lastUpdatedBy}
@@ -189,7 +189,7 @@ export default function ClientRulePage(props: ClientRulePageProps) {
                   {/* TODO: update link when migration is done (path will be wrong as reules will be in public folder) */}
                   <a href={`https://github.com/SSWConsulting/SSW.Rules.Content/commits/main/rules/${rule?.uri}/rule.md`}
                     target="_blank" title={historyTooltip}
-                    className="inline-flex items-center gap-1 font-semibold ssw-link" >
+                    className="inline-flex items-center gap-1 font-semibold underline" >
                     See history <RiHistoryLine />
                   </a>
                 </p>

--- a/app/profile/client-page.tsx
+++ b/app/profile/client-page.tsx
@@ -181,7 +181,7 @@ export default function ProfileClientPage({ data }: ProfileClientPageProps) {
                     <div className="text-3xl">
                     {isAuthenticated ? user?.name : ''}
                     </div>
-                    <a className="flex align-center ssw-link"
+                    <a className="flex align-center underline"
                       href={`https://www.github.com/${user?.nickname}`}
                       target="_blank"
                       rel="noreferrer"

--- a/components/RuleCard.tsx
+++ b/components/RuleCard.tsx
@@ -36,7 +36,7 @@ export default function RuleCard({
             <span className="font-medium">
               {authorUrl ? (
                 // Always treat authorUrl as external
-                <a href={authorUrl} target="_blank" rel="noopener noreferrer" className="ssw-link cursor-pointer">
+                <a href={authorUrl} target="_blank" rel="noopener noreferrer" className="underline">
                   {lastUpdatedBy || "Unknown"}
                 </a>
               ) : (

--- a/components/typography-components.tsx
+++ b/components/typography-components.tsx
@@ -54,7 +54,7 @@ export const getTypographyComponents = (enableAnchors = false) => ({
     <p className="mb-4" {...props} />
   ),
   a: (props: any) => (
-    <a className="ssw-link" {...props} />
+    <a className="underline" {...props} />
   ),
   blockquote: (props: any) => (
     <blockquote

--- a/styles.css
+++ b/styles.css
@@ -114,15 +114,6 @@
   @apply bg-ssw-red;
 }
 
-.ssw-link{
-  text-decoration: underline;
-  font-weight: 500;
-}
-
-.ssw-link:hover {
-  color: var(--ssw-red);
-}
-
 .action-btn-container {
   margin-left: auto;
   display: flex;


### PR DESCRIPTION
## Description

Related to: https://github.com/SSWConsulting/SSW.Rules/issues/2031

As per our conversation with @tiagov8 :
- Reverted changes to ssw-links
- Only used Tailwind's underline class to simplify CSS

## Screenshot (optional)

<img width="2560" height="1368" alt="image" src="https://github.com/user-attachments/assets/8e10a596-ce6c-4025-bddf-5bfef0ee4068" />

**Figure: standard links with underline only**

<img width="2560" height="1368" alt="image" src="https://github.com/user-attachments/assets/97a8e6e7-9afe-4369-93b8-1e67472e37c0" />

**Figure: emphasized links in rule subtitle**

