### PR TITLE
Get profile images using the people profile url instead of the name

### DIFF
--- a/components/Acknowledgements.tsx
+++ b/components/Acknowledgements.tsx
@@ -24,7 +24,7 @@ export default function Acknowledgements({ authors }: AcknowledgementsProps) {
 
     if (url?.includes('ssw.com.au/people')) {
       // Extract the part after '/people/'
-      const match = url.match(/people\/([^/]+)/);
+      const match = url.match(/people\/([^/?#]+)/);
       const slug = match ? match[1] : null;
 
       if (slug) {


### PR DESCRIPTION
## Description

We are fetching people profile images based on the names users input. Users could put anything they like casuing 404 errors for these images. 
This PR uses the ssw people profile name in the url rather than the name field

## Screenshot (optional)

Before:
<img width="1548" height="888" alt="image" src="https://github.com/user-attachments/assets/f7ec7aa9-e933-4f78-b32f-0abff62cf8bf" />

After:
<img width="1522" height="874" alt="image" src="https://github.com/user-attachments/assets/132abfa0-6761-4c69-8863-86199c08b9cb" />

