### PR TITLE
Changing order of the rich text editor buttons + delete the image but…

### DIFF
--- a/tina/collection/rule.tsx
+++ b/tina/collection/rule.tsx
@@ -129,6 +129,7 @@ const Rule: Collection = {
       label: "Body",
       isBody: true,
       templates: embedTemplates,
+      toolbarOverride: ['embed', 'heading', 'link', 'quote', 'ul', 'ol', 'bold', 'italic', 'code', 'codeBlock', 'mermaid', 'table', 'raw']
     },
     ...historyFields
   ],


### PR DESCRIPTION
## Description

In rich text editor:
- removing default image button (as we already have a custom one)
- moving "embed" button as the first one

## Screenshot (optional)

<img width="1903" height="906" alt="image" src="https://github.com/user-attachments/assets/28311b3b-25da-48e5-bbdd-95721301598f" />

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->