### PR TITLE
Centering the warning button in the aside box.

### DIFF
--- a/components/embeds/asideEmbed.tsx
+++ b/components/embeds/asideEmbed.tsx
@@ -91,7 +91,7 @@ export function AsideEmbed({ data }: { data: any }) {
     return (
       <ComponentWithFigure data={data}>
         <div className={`p-4 rounded-sm my-4 ${config.containerClass}`}>
-            <div className="flex items-start">
+            <div className="flex items-center">
             {config.icon}
             <div className={`prose prose-neutral prose-sm max-w-none text-base ${config.textClass ?? ""}`}>
                 <TinaMarkdown content={data.body} components={MarkdownComponentMapping} />


### PR DESCRIPTION
## Description

- Small UI fix: centering the aside custom component, vertically
- 
## Screenshot (optional)

<img width="1903" height="906" alt="image" src="https://github.com/user-attachments/assets/a60ea262-119c-456c-b7c1-a0f004bacd69" />

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->