### PR TITLE
Add hover effect to anchor tags in tina typography components

### DIFF
--- a/components/typography-components.tsx
+++ b/components/typography-components.tsx
@@ -54,7 +54,7 @@ export const getTypographyComponents = (enableAnchors = false) => ({
     <p className="mb-4" {...props} />
   ),
   a: (props: any) => (
-    <a className="underline" href={props.url} {...props} />
+    <a className="underline hover:text-ssw-red" href={props.url} {...props} />
   ),
   li: (props) => (
     <li {...props} />


### PR DESCRIPTION
## Description

Adding hover red underline

## Screenshot (optional)
<img width="1272" height="872" alt="image" src="https://github.com/user-attachments/assets/da31223e-532d-459f-a864-a203ba446c57" />

