### PR TITLE
Updating Rules number display in Rules category

### DIFF
--- a/app/[filename]/client-category-page.tsx
+++ b/app/[filename]/client-category-page.tsx
@@ -117,6 +117,7 @@ export default function ClientCategoryPage(props: ClientCategoryPageProps) {
         <div className="w-full lg:w-2/3 bg-white pt-4 p-6 border border-[#CCC] rounded shadow-lg">
           <h1 className="m-0 mb-2 text-ssw-red font-bold">
             {showArchivedFromUrl ? `Archived Rules - ${category?.title}` : category?.title}
+            <span className="text-gray-500 font-normal text-[0.75em]"> - {annotatedRules.length} {annotatedRules.length === 1 ? 'Rule' : 'Rules'}</span>
           </h1>
           <div className="flex gap-2 justify-center my-2 md:hidden">
             <IconLink

--- a/components/rule-list/rule-list.tsx
+++ b/components/rule-list/rule-list.tsx
@@ -110,8 +110,6 @@ const RuleList: React.FC<RuleListProps> = ({ categoryUri, rules, type, noContent
               <span className="text-gray-700">Include Archived</span>
             </label>
           )}
-
-          {showFilterControls && (<span className="mx-3 hidden sm:block">{rules.length} Rules</span>)}
         </div>
         {type === 'category' && (
           <div className="hidden md:flex gap-2">


### PR DESCRIPTION
(cherry picked from commit 2f60d288a9b99752f41ead657e37c2420f29a348)

## Description

Showing the rules number in category title.
https://github.com/SSWConsulting/SSW.Rules/issues/2041

## Screenshot (optional)

<img width="1903" height="906" alt="image" src="https://github.com/user-attachments/assets/c318b88e-ed72-48bb-b3dd-b2eefbba8189" />


<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->