### PR TITLE
🐛 Fix ruleCategoriesMapping and relatedRulesMapping props

### DIFF
--- a/components/ServerRulePage.tsx
+++ b/components/ServerRulePage.tsx
@@ -32,9 +32,12 @@ export default function ServerRulePage({
 }: ServerRulePagePropsWithTinaProps) {
   const { data } = tinaProps;
   const rule = data?.rule;
-  const ruleCategoriesMapping = data?.ruleCategoriesMapping;
-  const relatedRulesMapping = data?.relatedRulesMapping;
-  const sanitizedBasePath = data?.sanitizedBasePath;
+  
+  const {
+    ruleCategoriesMapping,
+    relatedRulesMapping,
+    sanitizedBasePath,
+  } = serverRulePageProps;
 
   const relativeTime = rule?.lastUpdated ? timeAgo(rule.lastUpdated) : "";
   const created = rule?.created ? formatDateLong(rule.created) : "Unknown";


### PR DESCRIPTION
## Description
✏️ 
Ensure ServerRulePage reads ruleCategoriesMapping and relatedRulesMapping from serverRulePageProps instead of data.

## Screenshot (optional)
✏️ 
<img width="2575" height="1598" alt="image" src="https://github.com/user-attachments/assets/7cf37cc7-f03a-4c8a-9754-30c7a06bf9a7" />


<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->