### PR TITLE
Lowering the concurrency to avoid exceeding TinaCloud limits

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -81,8 +81,8 @@ const nextConfig: NextConfig = {
     // Without it, the static generation of the app will take a 52 minutes.
     // With it, the static generation of the app will take a 11 minutes.
     staticGenerationRetryCount: 2,
-    staticGenerationMaxConcurrency: 200,
-    staticGenerationMinPagesPerWorker: 100,
+    staticGenerationMaxConcurrency: 50,
+    staticGenerationMinPagesPerWorker: 25,
   },
   async rewrites() {
     return [


### PR DESCRIPTION
higher number could affect other TinaCloud users and raise costs. The build time has only gone from 13 minutes to 20 minutes.