### PR TITLE
🐛 Add Bath Path for internal link in rule's content

### DIFF
--- a/components/typography-components.tsx
+++ b/components/typography-components.tsx
@@ -2,6 +2,7 @@ import { Prism } from "tinacms/dist/rich-text/prism";
 import React from "react";
 import { Link as LinkIcon } from "lucide-react";
 import { toSlug } from "@/lib/utils";
+import Link from "next/link";
 
 // Helper function to extract text content from TinaCMS props structure
 const getTextContent = (props: any): string => {
@@ -53,9 +54,28 @@ export const getTypographyComponents = (enableAnchors = false) => ({
   p: (props: any) => (
     <p className="mb-4" {...props} />
   ),
-  a: (props: any) => (
-    <a className="underline hover:text-ssw-red" href={props.url} {...props} />
-  ),
+  a: (props: any) => {
+    const href = props?.url || props?.href || "";
+    const isInternal =
+      typeof href === "string" &&
+      href.startsWith("/") &&
+      !href.startsWith("//") &&
+      !href.startsWith("/_next");
+
+    if (isInternal) {
+      return (
+        <Link href={href} className="underline hover:text-ssw-red">
+          {props.children}
+        </Link>
+      );
+    }
+
+    return (
+      <a className="underline hover:text-ssw-red" href={href} {...props}>
+        {props.children}
+      </a>
+    );
+  },
   li: (props) => (
     <li {...props} />
   ),


### PR DESCRIPTION
## Description
✏️ 

Relates to https://github.com/SSWConsulting/SSW.Rules/issues/2073

Added bathPath for internal links so they will not be broken on staging/prod

## Screenshot (optional)
✏️ 
<img width="1061" height="989" alt="image" src="https://github.com/user-attachments/assets/338a071e-8cc4-429b-bc0e-1d2aeb5b3701" />


<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->