### PR TITLE
Adjust heading margin for improved spacing in embed h tags

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -226,7 +226,7 @@
   h4,
   h5,
   h6 {
-    @apply mt-8 text-gray-900 leading-[1.2] mb-4 font-semibold;
+    @apply mt-2 mb-4 text-gray-900 leading-[1.2] font-semibold;
   }
 
   h2 {


### PR DESCRIPTION
## Description

Fixing margin for h tags in embeds

## Screenshot (optional)

Before:
<img width="792" height="240" alt="image" src="https://github.com/user-attachments/assets/ae22bdd7-b002-47f9-96af-86d5047b5db7" />

After:
<img width="860" height="240" alt="image" src="https://github.com/user-attachments/assets/bb78c2d5-2b95-41cc-ae8e-b18772170cc6" />

