### PR TITLE
Rename dev branch references in documentation

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -5,7 +5,7 @@ on:
 env:
   NEXT_PUBLIC_TINA_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_TINA_CLIENT_ID }}
   TINA_TOKEN: ${{ secrets.TINA_TOKEN }}
-  NEXT_PUBLIC_TINA_BRANCH: tina/migration-main-content # TODO - Change to main when production is ready
+  NEXT_PUBLIC_TINA_BRANCH: tina-migration-main-content # TODO - Change to main when production is ready
   TOKEN: ${{ secrets.POC_PAT_GILLES }}
   NEXT_PUBLIC_ALGOLIA_APP_ID: ${{ secrets.NEXT_PUBLIC_ALGOLIA_APP_ID }}
   NEXT_PUBLIC_ALGOLIA_ADMIN_KEY: ${{ secrets.NEXT_PUBLIC_ALGOLIA_ADMIN_KEY }}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The site pulls data from [SSW Rules Content Repo 📜](https://github.com/SSWCon
 
 1. Clone this repo
 
-2. Clone [SSW.Rules.Content](https://github.com/SSWConsulting/SSW.Rules.content) and switch to the `tina/migration-dev-content` branch
+2. Clone [SSW.Rules.Content](https://github.com/SSWConsulting/SSW.Rules.content) and switch to the `tina-migration-dev-content` branch
 
 3. Place both repos in the same parent directory e.g.
 ```
@@ -41,7 +41,7 @@ The site pulls data from [SSW Rules Content Repo 📜](https://github.com/SSWCon
 ### Syncing and Updating Content
 To test changes to MDX rules:
 
-1. Go to the `tina/migration-dev-content` branch of SSW.Rules.Content
+1. Go to the `tina-migration-dev-content` branch of SSW.Rules.Content
 
 2. Modify the rule MDX as needed
 

--- a/scripts/prepare-content-build.js
+++ b/scripts/prepare-content-build.js
@@ -24,7 +24,7 @@ console.log('Preparing content for build...');
 
 // Hardcoded for now - can be moved to env vars later
 const contentRepoUrl = 'https://github.com/SSWConsulting/SSW.Rules.Content.git';
-const contentBranch = process.env.NEXT_PUBLIC_TINA_BRANCH || 'tina/migration-dev-content';
+const contentBranch = process.env.NEXT_PUBLIC_TINA_BRANCH || 'tina-migration-dev-content';
 
 console.log(`Cloning content repo: ${contentRepoUrl} (branch: ${contentBranch})`);
 


### PR DESCRIPTION
## Description
✏️ 
Renames all dev branch mentions in docs to reflect the updated branch name.

## Screenshot (optional)
✏️ 

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->