### PR TITLE
Check unmatched uris for rule redirects + code clean up

### DIFF
--- a/components/RelatedRules.tsx
+++ b/components/RelatedRules.tsx
@@ -85,16 +85,20 @@ const RelatedRules = ({ relatedUris, initialMapping }: RelatedRulesProps) => {
         const nextMatches = addedRedirects.length ? [...directMatches, ...addedRedirects] : directMatches;
         if (!areRuleListsEqual(nextMatches, rules)) setRules(nextMatches);
 
-        // 4) Figure out which requested URIs are fulfilled (directly or via redirect)
-        const fulfilledRequests = new Set<string>();
-        for (const req of requestedUris) {
-          const redirectTarget = redirectMap[req];
-          if (matchedUris.has(req) || (redirectTarget && matchedUris.has(redirectTarget))) {
-            fulfilledRequests.add(req);
+        // 4) Set not found uris if not on admin page
+        if (isAdminPage) {
+          const fulfilledRequests = new Set<string>();
+          for (const req of requestedUris) {
+            const redirectTarget = redirectMap[req];
+            if (matchedUris.has(req) || (redirectTarget && matchedUris.has(redirectTarget))) {
+              fulfilledRequests.add(req);
+            }
           }
+          const finalUnmatched = requestedUris.filter((u) => !fulfilledRequests.has(u));
+          setConfirmedNotFound(finalUnmatched);
+        } else if (confirmedNotFound.length) {
+          setConfirmedNotFound([]);
         }
-        const finalUnmatched = requestedUris.filter((u) => !fulfilledRequests.has(u));
-        setConfirmedNotFound(finalUnmatched);
       } catch (error) {
         console.error(error);
       }


### PR DESCRIPTION
## Description

This PR checks the redirects list for any unmatched related rule uris and displays the Related Rule in the list

## Screenshot (optional)

<img width="1733" height="1039" alt="image" src="https://github.com/user-attachments/assets/ec584045-9163-4827-88a7-561037a1792c" />

<img width="1096" height="899" alt="image" src="https://github.com/user-attachments/assets/fa42da68-b188-49b1-85e9-fd614cf72552" />
