### PR TITLE
Remove duplicate "rules-beta" in the url

### DIFF
--- a/tina/collection/rule.tsx
+++ b/tina/collection/rule.tsx
@@ -32,7 +32,7 @@ const Rule: Collection = {
       const slug =
         document?._sys?.relativePath?.split("/")?.[0] ??
         "";
-      return `${basePath}/${slug}`;
+      return `/${slug}`;
     },
     beforeSubmit: historyBeforeSubmit,
   },


### PR DESCRIPTION
## Description
✏️ 
  Removed double "rules-beta" in the tina admin panel

## Screenshot (optional)
✏️ 

Remove this:
<img width="2125" height="862" alt="image" src="https://github.com/user-attachments/assets/49ccd0d8-eaf3-4edb-8353-a83afe23fd45" />


<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->