### PR TITLE
Rule page - adding meta description using seoDescription prop

### DIFF
--- a/app/[filename]/page.tsx
+++ b/app/[filename]/page.tsx
@@ -300,9 +300,15 @@ export async function generateMetadata({
 
     const rule = await getRuleData(filename);
     if (rule?.data?.rule?.title) {
-      return {
+      const metadata: any = {
         title: `${rule.data.rule.title} | SSW.Rules`,
       };
+
+      if (rule.data.rule.seoDescription) {
+        metadata.description = rule.data.rule.seoDescription;
+      }
+
+      return metadata;
     }
   } catch (error) {
     console.error("Error generating metadata:", error);


### PR DESCRIPTION
## Description

Related to: https://github.com/SSWConsulting/SSW.Rules/issues/2060

- Added meta description tag using _seoDescription_ when available

## Screenshot (optional)

<img width="1720" height="1380" alt="image" src="https://github.com/user-attachments/assets/72f8b270-5997-4045-a7a0-5dc97fc20aec" />

**Figure: seoDescription field**

<img width="1729" height="1380" alt="image" src="https://github.com/user-attachments/assets/44fc478f-6515-4aac-b46d-c20ac5c772e7" />

**Figure: meta tag with the seoDescription set**