### PR TITLE
Revalidate Category page on content change

### DIFF
--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -36,7 +36,7 @@ export async function POST(req: Request) {
         }
         // If change type is add then we also need to revalidate the /api/rules route
         if (eventType === TINA_CONTENT_CHANGE_TYPE.Added) {
-          routesToRevalidate.add("/rules");
+          routesToRevalidate.add("/api/rules");
         }
       }
 


### PR DESCRIPTION
## Description

When a user makes changes to a category page, we are currently not revalidating the path and therefore the user will not see their changes reflected.
This PR adds revalidation on category pages when content changes
