### PR TITLE
Fixing broken links in Archived Reason boxes

### DIFF
--- a/app/[filename]/ServerRulePage.tsx
+++ b/app/[filename]/ServerRulePage.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import { tinaField } from "tinacms/dist/react";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
+import ArchivedReasonContent from "@/components/ArchivedReasonContent";
 import AuthorsCard from "@/components/AuthorsCard";
 import Breadcrumbs from "@/components/Breadcrumbs";
 import CategoriesCard from "@/components/CategoriesCard";
@@ -70,14 +71,9 @@ export default function ServerRulePage({ serverRulePageProps, tinaProps }: Serve
                 </div>
                 <div className="flex-1">
                   <h3 className="text-sm font-semibold text-ssw-red m-0 mb-1">This rule has been archived</h3>
-                  <div
-                    className="text-sm text-ssw-red m-0"
-                    dangerouslySetInnerHTML={{
-                      __html: rule.archivedreason
-                        ?.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" class="text-ssw-red underline hover:opacity-80">$1</a>')
-                        ?.replace(/https?:\/\/[^\s]+/g, '<a href="$&" class="text-ssw-red underline hover:opacity-80">$&</a>'),
-                    }}
-                  />
+                  <div className="text-sm text-ssw-red m-0">
+                    <ArchivedReasonContent reason={rule.archivedreason} />
+                  </div>
                 </div>
               </div>
             </div>

--- a/components/ArchivedReasonContent.tsx
+++ b/components/ArchivedReasonContent.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import Link from "next/link";
+import React from "react";
+
+interface ArchivedReasonContentProps {
+  reason: string;
+  className?: string;
+}
+
+interface ParsedSegment {
+  type: "text" | "link";
+  content: string;
+  href?: string;
+}
+
+function parseArchivedReason(reason: string): ParsedSegment[] {
+  const segments: ParsedSegment[] = [];
+
+  // Match Markdown links: [text](url)
+  const markdownLinkRegex = /\[([^\]]+)\]\(([^)]+)\)/g;
+
+  let lastIndex = 0;
+  let match;
+
+  while ((match = markdownLinkRegex.exec(reason)) !== null) {
+    // Add text before the match
+    if (match.index > lastIndex) {
+      const textBefore = reason.slice(lastIndex, match.index);
+      if (textBefore) {
+        segments.push({ type: "text", content: textBefore });
+      }
+    }
+
+    const linkText = match[1];
+    const linkHref = match[2];
+
+    segments.push({
+      type: "link",
+      content: linkText,
+      href: linkHref,
+    });
+
+    lastIndex = match.index + match[0].length;
+  }
+
+  // Add remaining text after last match
+  if (lastIndex < reason.length) {
+    const remainingText = reason.slice(lastIndex);
+    if (remainingText) {
+      segments.push({ type: "text", content: remainingText });
+    }
+  }
+
+  // If no markdown links were found, check for plain URLs
+  if (segments.length === 0 || (segments.length === 1 && segments[0].type === "text")) {
+    const text = segments.length === 1 ? segments[0].content : reason;
+    const urlRegex = /(https?:\/\/[^\s<>"']+)/g;
+
+    const newSegments: ParsedSegment[] = [];
+    let urlLastIndex = 0;
+    let urlMatch;
+
+    while ((urlMatch = urlRegex.exec(text)) !== null) {
+      if (urlMatch.index > urlLastIndex) {
+        const textBefore = text.slice(urlLastIndex, urlMatch.index);
+        if (textBefore) {
+          newSegments.push({ type: "text", content: textBefore });
+        }
+      }
+
+      newSegments.push({
+        type: "link",
+        content: urlMatch[1],
+        href: urlMatch[1],
+      });
+
+      urlLastIndex = urlMatch.index + urlMatch[0].length;
+    }
+
+    if (urlLastIndex < text.length) {
+      const remainingText = text.slice(urlLastIndex);
+      if (remainingText) {
+        newSegments.push({ type: "text", content: remainingText });
+      }
+    }
+
+    if (newSegments.length > 0) {
+      return newSegments;
+    }
+  }
+
+  return segments.length > 0 ? segments : [{ type: "text", content: reason }];
+}
+
+function isInternalLink(href: string): boolean {
+  // Internal links start with / or are relative paths (not starting with http/https)
+  if (href.startsWith("/")) {
+    return true;
+  }
+
+  // Check if it's an SSW rules link that should be treated as internal
+  const sswRulesPattern = /^https?:\/\/(www\.)?ssw\.com\.au\/rules\//;
+  return sswRulesPattern.test(href);
+}
+
+function normalizeInternalHref(href: string): string {
+  // Convert SSW rules URLs to internal paths
+  const sswRulesPattern = /^https?:\/\/(www\.)?ssw\.com\.au\/rules\/(.+)$/;
+  const match = href.match(sswRulesPattern);
+
+  if (match) {
+    return `/${match[2]}`;
+  }
+
+  // Handle /uploads/rules/xxx paths - convert to /xxx
+  if (href.startsWith("/uploads/rules/")) {
+    const rulePath = href.replace("/uploads/rules/", "");
+    return `/${rulePath}`;
+  }
+
+  return href;
+}
+
+export default function ArchivedReasonContent({ reason, className = "" }: ArchivedReasonContentProps) {
+  const segments = parseArchivedReason(reason);
+
+  const linkClassName = "text-ssw-red underline hover:opacity-80";
+
+  return (
+    <span className={className}>
+      {segments.map((segment, index) => {
+        if (segment.type === "text") {
+          return <React.Fragment key={index}>{segment.content}</React.Fragment>;
+        }
+
+        const href = segment.href || "";
+        const isInternal = isInternalLink(href);
+
+        if (isInternal) {
+          const normalizedHref = normalizeInternalHref(href);
+          return (
+            <Link key={index} href={normalizedHref} className={linkClassName}>
+              {segment.content}
+            </Link>
+          );
+        }
+
+        return (
+          <a key={index} href={href} className={linkClassName} target="_blank" rel="noopener noreferrer">
+            {segment.content}
+          </a>
+        );
+      })}
+    </span>
+  );
+}

--- a/components/tooltip/tooltip.js
+++ b/components/tooltip/tooltip.js
@@ -33,7 +33,7 @@ const Tooltip = ({ children, text, showDelay, hideDelay, className = '', opaque 
       {showTooltip && (
         <span
           className={
-            `absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded-md bg-gray-800 px-2 py-1 text-xs text-white transition-opacity duration-200 before:absolute before:top-full before:left-1/2 before:-translate-x-1/2 before:border-4 before:border-solid before:border-gray-800 before:border-l-transparent before:border-r-transparent before:border-b-transparent before:content-[''] ${
+            `absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-50 whitespace-nowrap rounded-md bg-gray-800 px-2 py-1 text-xs text-white transition-opacity duration-200 before:absolute before:top-full before:left-1/2 before:-translate-x-1/2 before:border-4 before:border-solid before:border-gray-800 before:border-l-transparent before:border-r-transparent before:border-b-transparent before:content-[''] ${
               opaque ? 'opacity-100' : 'opacity-0 group-hover:opacity-50'
             }`
           }


### PR DESCRIPTION
## Description

PBI - [#2196-Archivec_reason_links](https://github.com/SSWConsulting/SSW.Rules/issues/2196)

I've replaced the dangerouslySetInnerHTML approach with a new ArchivedReasonContent React component that properly parses Markdown links and uses Next.js Link for internal navigation. 

Related Content PR - https://github.com/SSWConsulting/SSW.Rules.Content/pull/11501
 
## Screenshot (optional)
N/A

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->